### PR TITLE
Syntax highlighting on .eliom files

### DIFF
--- a/grammars/ocaml.cson
+++ b/grammars/ocaml.cson
@@ -1,6 +1,7 @@
 'fileTypes': [
   'ml'
   'mli'
+  'eliom'
 ]
 'foldingStartMarker': '(\\b(module|class|)\\s.*?=\\s*$|\\bbegin|sig|struct|(object(\\s*\\(_?[a-z]+\\))?)\\s*$|\\bwhile\\s.*?\\bdo\\s*$|^let(?:\\s+rec)?\\s+[a-z_][a-zA-Z0-9_]*\\s+(?!=)\\S)'
 'foldingStopMarker': '(\\bend(\\s+in)?[ \\t]*(;{1,2}|=)?|\\bdone;?|^\\s*;;|^\\s*in)[ \\t]*$'


### PR DESCRIPTION
.eliom files are almost standard ocaml files used by Ocsigen http://ocsigen.org/