### PR TITLE
Fix keyword.control.match-definition.ocaml on first line of match/function

### DIFF
--- a/grammars/ocaml.cson
+++ b/grammars/ocaml.cson
@@ -113,7 +113,7 @@
         'name': 'keyword.other.function-definition.ocaml'
       '3':
         'name': 'keyword.control.match-definition.ocaml'
-    'end': '(?:(->)|\\b(when)\\b|\\s(?=\\|))'
+    'end': '(?:(->)|\\b(when)\\b|(?:^|\\s)(?=\\|))'
     'endCaptures':
       '1':
         'name': 'punctuation.separator.match-definition.ocaml'


### PR DESCRIPTION
A `|` on the first line of a match or function was recognized as a `punctuation.separator.match-pattern.ocaml` instead of a `keyword.control.match-definition.ocaml` like it is on subsequent lines.

Some examples of what `meta.pattern-match.ocaml` matches:

```
... with Foo -> "this is not matched" | Bar -> ...
    ^^^^^^^^^^^                       ^^^^^^^^
```

`with Foo ->` and `| Bar ->` are separate matches.

```
... with
    ^^^^
Foo -> ...
^^^^^^
| Bar -> ...
^^^^^^^^
```

`with\nFoo ->` and `| Bar ->` are similarly separate matches.

Before this PR, if the line was `| Foo ->`, then the `end` didn't match a `\s`, so the whole `with\n| Foo ->` was one match, causing the `|` to be handled by `matchpatterns` instead.

After this PR, there will be 3 separate matches, one for `with`, one for `| Foo ->` and one for `| Bar ->`.

before:
![screen shot 2015-06-30 at 6 46 44 pm](https://cloud.githubusercontent.com/assets/3012/8445968/c0b491b8-1f58-11e5-910c-b23f8fb9ba2a.png)

after:
![screen shot 2015-06-30 at 6 45 52 pm](https://cloud.githubusercontent.com/assets/3012/8445974/c88a55a8-1f58-11e5-8222-41d110e08283.png)