### PR TITLE
Improve highlighting of first class modules

### DIFF
--- a/grammars/ocaml.cson
+++ b/grammars/ocaml.cson
@@ -421,6 +421,23 @@
     'include': '#arrays'
   }
   {
+    'begin': '\\((val)\\s+'
+    'beginCaptures':
+      '1':
+        'name': 'keyword.other.ocaml'
+    'end': '(?:\\s+(:)\\s+([a-zA-Z_][a-zA-Z0-9_\']*))?\\)'
+    'endCaptures':
+      '1':
+        'name': 'punctuation.separator.optional-parameter.ocaml'
+      '2':
+        'name': 'storage.type.ocaml'
+    'patterns': [
+      {
+        'include': '$self'
+      }
+    ]
+  }
+  {
     'begin': '(\\()(?=(~[a-z][a-zA-Z0-9_]*:|("(\\\\"|[^"])*")|[^\\(\\)~"])+(?<!:)(:>|:(?![:=])))'
     'beginCaptures':
       '1':

--- a/grammars/ocaml.cson
+++ b/grammars/ocaml.cson
@@ -431,6 +431,7 @@
         'name': 'punctuation.separator.optional-parameter.ocaml'
       '2':
         'name': 'storage.type.ocaml'
+    'name': 'meta.module.signature.val.ocaml'
     'patterns': [
       {
         'include': '$self'


### PR DESCRIPTION
Before:
![screen shot 2015-06-30 at 7 19 02 pm](https://cloud.githubusercontent.com/assets/3012/8446298/37e3d984-1f5d-11e5-97c5-77fbf830d62f.png)

After:
![screen shot 2015-06-30 at 7 18 29 pm](https://cloud.githubusercontent.com/assets/3012/8446304/3c80256a-1f5d-11e5-9153-df363b448c17.png)

Test cases come from http://caml.inria.fr/pub/docs/manual-ocaml/extn.html#sec230

Highlighting on lines 2-4 and 8 are improved. Aside from the coloring, before this fix, `meta.module.signature.val.ocaml` starts matching on the val on line 8 and continues until it hits the blank line on line 11, which makes no sense.

(This is a port of the same fix to Sublime's fork of the original TextMate grammar... see also https://github.com/whitequark/sublime-better-ocaml/pull/2)