### PR TITLE
support `let open MyModule` syntax

### DIFF
--- a/grammars/ocaml.cson
+++ b/grammars/ocaml.cson
@@ -21,6 +21,27 @@
     'name': 'meta.module.binding'
   }
   {
+    'begin': '\\b(let)\\s+(open)\\s+([A-Z][a-zA-Z0-9\'_]*)(?=(\\.[A-Z][a-zA-Z0-9_]*)*)'
+    'beginCaptures':
+      '1':
+        'name': 'keyword.other.module-binding.ocaml'
+      '2':
+        'name': 'keyword.other.ocaml'
+      '3':
+        'name': 'support.other.module.ocaml'
+    'end': '(\\s|$)'
+    'name': 'meta.module.openbinding'
+    'patterns': [
+      {
+        'captures':
+          '1':
+            'name': 'punctuation.separator.module-reference.ocaml'
+        'match': '(\\.)([A-Z][a-zA-Z0-9\'_]*)'
+        'name': 'support.other.module.ocaml'
+      }
+    ]
+  }
+  {
     'begin': '\\b(let|and)\\s+(?!\\(\\*)((rec\\s+)([a-z_][a-zA-Z0-9_\']*)\\b|([a-z_][a-zA-Z0-9_\']*|\\([^)]+\\))(?=\\s)((?=\\s*=\\s*(?=fun(?:ction)\\b))|(?!\\s*=)))'
     'beginCaptures':
       '1':


### PR DESCRIPTION
port of https://github.com/textmate/ocaml.tmbundle/commit/be9b450699a38d1734dc2a698780e177b3acde8e

Fixes #6 

before:
![screen shot 2015-06-30 at 10 35 55 pm](https://cloud.githubusercontent.com/assets/3012/8448171/df5d95c2-1f78-11e5-95c7-15a6e054af67.png)

after:
![screen shot 2015-06-30 at 10 36 46 pm](https://cloud.githubusercontent.com/assets/3012/8448172/e57f6fde-1f78-11e5-88e3-0b6d54fbbdf6.png)
