### PR TITLE
Support proper nested block comments

### DIFF
--- a/grammars/ocaml.cson
+++ b/grammars/ocaml.cson
@@ -633,6 +633,12 @@
           }
         ]
       }
+    ]
+  'comments_inner':
+    'patterns': [
+      {
+        'include': '#comments'
+      }
       {
         'begin': '(?=[^\\\\])(")'
         'end': '"'
@@ -920,7 +926,7 @@
         'name': 'punctuation.separator.variant-definition.ocaml'
       }
       {
-        'include': '#comments'
+        'include': '#comments_inner'
       }
       {
         'begin': '\\('
@@ -1068,7 +1074,7 @@
         ]
       }
       {
-        'include': '#comments'
+        'include': '#comments_inner'
       }
       {
         'begin': '\\('


### PR DESCRIPTION
port of https://github.com/textmate/ocaml.tmbundle/commit/fac9c384979b5c86098fb869ad0f50f938be34a8

before:
![screen shot 2015-06-30 at 11 02 26 pm](https://cloud.githubusercontent.com/assets/3012/8448473/e9046e8a-1f7c-11e5-891b-fd4f6f3091eb.png)

after:
![screen shot 2015-06-30 at 11 05 18 pm](https://cloud.githubusercontent.com/assets/3012/8448475/ece96f50-1f7c-11e5-8405-c34aefb93873.png)
