### PR TITLE
Add asr operator

### DIFF
--- a/grammars/ocaml.cson
+++ b/grammars/ocaml.cson
@@ -573,7 +573,7 @@
     ]
   }
   {
-    'match': '\\b(and|land|lor|lsl|lsr|lxor|mod|or)\\b'
+    'match': '\\b(and|asr|land|lor|lsl|lsr|lxor|mod|or)\\b'
     'name': 'keyword.operator.ocaml'
   }
   {


### PR DESCRIPTION
Partial port of https://github.com/textmate/ocaml.tmbundle/commit/8158940052861bcf90c28f343dff2c50ab440b3f

I didn't include lnot because it's not an infix operator. If lnot should be included, then so should be succ, pred, abs, max_int, min_int, etc. and I don't think it makes sense to include all of the random functions of Pervasives.