### PR TITLE
Fix for anonymous functions consuming closing parens

### DIFF
--- a/grammars/ocaml.cson
+++ b/grammars/ocaml.cson
@@ -70,7 +70,7 @@
     ]
   }
   {
-    'begin': '(\\(|\\s)(?=fun\\s)'
+    'begin': '(\\()(?=fun\\s)'
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.function.anonymous.ocaml'
@@ -81,20 +81,20 @@
     'name': 'meta.function.anonymous.ocaml'
     'patterns': [
       {
-        'begin': '(?<=(\\(|\\s))(fun)\\s'
-        'beginCaptures':
-          '2':
-            'name': 'keyword.other.function-definition.ocaml'
-        'end': '(->)'
-        'endCaptures':
-          '1':
-            'name': 'punctuation.separator.function-definition.ocaml'
-        'name': 'meta.function.anonymous.definition.ocaml'
-        'patterns': [
-          {
-            'include': '#variables'
-          }
-        ]
+        'include': '#anonymous-function-def'
+      }
+      {
+        'include': '$self'
+      }
+    ]
+  }
+  {
+    'begin': '(\\s)(?=fun\\s)'
+    'end': '(?=\\))'
+    'name': 'meta.function.anonymous.ocaml'
+    'patterns': [
+      {
+        'include': '#anonymous-function-def'
       }
       {
         'include': '$self'
@@ -632,6 +632,25 @@
   }
 ]
 'repository':
+  'anonymous-function-def':
+    'patterns': [
+      {
+        'begin': '(?<=(\\(|\\s))(fun)\\s'
+        'beginCaptures':
+          '2':
+            'name': 'keyword.other.function-definition.ocaml'
+        'end': '(->)'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.separator.function-definition.ocaml'
+        'name': 'meta.function.anonymous.definition.ocaml'
+        'patterns': [
+          {
+            'include': '#variables'
+          }
+        ]
+      }
+    ]
   'arrays':
     'patterns': [
       {


### PR DESCRIPTION
Given something like `let foo ?(bar = fun x -> x) -> ...` (a function that takes a function, with a default anonymous function), the previous rule would match on `\s(?=fun\s)` and consume the trailing `)`, which threw off the paren balance.

Now we still end on a closing paren, but don't consume it if we didn't consume the opening paren. Ending anonymous functions only when we encounter a closing paren doesn't seem 100% legit but I can't think of anything else to do, and it's how it worked before.