### PR TITLE
Fix two ocamllex syntax highlighting bugs

### DIFF
--- a/grammars/menhir.cson
+++ b/grammars/menhir.cson
@@ -219,14 +219,16 @@
   'rules':
     'patterns': [
       {
-        'begin': '([a-z][a-zA-Z_]*)(?>\\s*(:|\\|))'
+        'begin': '(?:(%public|%inline)\\s*)?([a-z][a-zA-Z_]*)(?:\\s*\\(.*?\\))?(?=\\s*(:|\\|))'
         'beginCaptures':
           '1':
+            'name': 'keyword.other.menhir'
+          '2':
             'name': 'entity.name.function.non-terminal.rule.begin.menhir'
         'end': '(?<=})\s(?!\\|)'
         'endCaptures':
           '0':
-            'name': 'entity.name.function.non-terminal.rule.end.menhir'        
+            'name': 'entity.name.function.non-terminal.rule.end.menhir'
         'name': 'meta.non-terminal.rule.menhir'
         'patterns': [{ 'include': '#rule-patterns' }]
       }

--- a/grammars/menhir.cson
+++ b/grammars/menhir.cson
@@ -2,7 +2,21 @@
 'fileTypes': ['mly']
 'scopeName': 'source.menhir'
 'patterns': [
-  {'include': '#declaration'}
+  {
+    'begin': '(?=%[^%])'
+    'end': '(?=%%)'
+    'patterns': [{'include': '#declaration'}]
+  }
+  {
+    'begin': '%%'
+    'beginCaptures':
+      '0': {'name': 'keyword.other.rules.begin.menhir'}
+    'end': '%%'
+    'endCaptures':
+      '0': {'name': 'keyword.other.rules.end.menhir'}
+    'patterns': [{'include': '#rule'}]
+  }
+  {'include': 'source.ocaml'}
 ]
 'repository':
   'declaration':
@@ -53,15 +67,6 @@
         'captures':
           '1': {'name': 'keyword.other.directive.menhir'}
           '2': {'patterns': [{'include': '#lident'}]}
-      }
-      {
-        'begin': '%%'
-        'beginCaptures':
-          '0': {'name': 'keyword.other.rules.begin.menhir'}
-        'end': '%%'
-        'endCaptures':
-          '0': {'name': 'keyword.other.rules.end.menhir'}
-        'patterns': [{'include': '#rule'}]
       }
     ]
   'rule':

--- a/grammars/menhir.cson
+++ b/grammars/menhir.cson
@@ -217,7 +217,7 @@
             'name': 'keyword.other.menhir'
           '2':
             'name': 'entity.name.function.non-terminal.rule.begin.menhir'
-        'end': '(?<=})\\s*(?!\\|)|'
+        'end': '(?=[^{}]+:)'
         'endCaptures':
           '0':
             'name': 'entity.name.function.non-terminal.rule.end.menhir'

--- a/grammars/menhir.cson
+++ b/grammars/menhir.cson
@@ -128,6 +128,10 @@
     'patterns': [{'include': '#reference'}]
   'reference':
     'patterns': [
+      {
+        'match': '\\b(?:[ibl]?option|pair|separated_pair|preceded|terminated|delimited|list|nonempty_list|separated_list|separated_nonempty_list)\\b',
+        'name': 'support.function.rule.menhir'
+      }
       {'include': '#uident'}
       {'include': '#lident'}
     ]

--- a/grammars/menhir.cson
+++ b/grammars/menhir.cson
@@ -9,11 +9,11 @@
     'begin': '(%{)\\s*$'
     'beginCaptures':
       '1':
-        'name': 'punctuation.section.header.begin.menhir'
+        'name': 'keyword.operator.header.begin.menhir'
     'end': '^\\s*(%})'
     'endCaptures':
       '1':
-        'name': 'punctuation.section.header.end.menhir'
+        'name': 'keyword.operator.header.end.menhir'
     'name': 'meta.header.menhir'
     'patterns': [{ 'include': 'source.ocaml' }]
   }
@@ -30,11 +30,11 @@
     'begin': '(%%)\\s*$'
     'beginCaptures':
       '1':
-        'name': 'punctuation.section.rules.begin.menhir'
+        'name': 'keyword.operator.rules.begin.menhir'
     'end': '^\\s*(%%)'
     'endCaptures':
       '1':
-        'name': 'punctuation.section.rules.end.menhir'
+        'name': 'keyword.operator.rules.end.menhir'
     'name': 'meta.rules.menhir'
     'patterns': [
       { 'include': '#comments' }
@@ -84,12 +84,10 @@
   'declaration-matches':
     'patterns': [
       {
-        'begin': '(%)(token)'
+        'begin': '%token'
         'beginCaptures':
-          '1':
-            'name': 'keyword.other.decorator.token.menhir'
-          '2':
-            'name': 'keyword.other.token.menhir'
+          '0':
+            'name': 'keyword.other.directive.token.menhir'
         'end': '^\\s*($|(^\\s*(?=%)))'
         'name': 'meta.token.declaration.menhir'
         'patterns': [
@@ -102,12 +100,10 @@
         ]
       }
       {
-        'begin': '(%)(left|right|nonassoc)'
+        'begin': '%left|%right|%nonassoc'
         'beginCaptures':
-          '1':
-            'name': 'keyword.other.decorator.token.associativity.menhir'
-          '2':
-            'name': 'keyword.other.token.associativity.menhir'
+          '0':
+            'name': 'keyword.other.directive.token.associativity.menhir'
         'end': '(^\\s*$)|(^\\s*(?=%))'
         'name': 'meta.token.associativity.menhir'
         'patterns': [
@@ -123,12 +119,10 @@
         ]
       }
       {
-        'begin': '(%)(start)'
+        'begin': '%start'
         'beginCaptures':
-          '1':
-            'name': 'keyword.other.decorator.start-symbol.menhir'
-          '2':
-            'name': 'keyword.other.start-symbol.menhir'
+          '0':
+            'name': 'keyword.other.directive.start-symbol.menhir'
         'end': '^\\s*($|(^\\s*(?=%)))'
         'name': 'meta.start-symbol.menhir'
         'patterns': [
@@ -141,12 +135,10 @@
         ]
       }
       {
-        'begin': '(%)(type)'
+        'begin': '%type'
         'beginCaptures':
-          '1':
-            'name': 'keyword.other.decorator.symbol-type.menhir'
-          '2':
-            'name': 'keyword.other.symbol-type.menhir'
+          '0':
+            'name': 'keyword.other.directive.type.menhir'
         'end': '$\\s*(?!%)'
         'name': 'meta.symbol-type.menhir'
         'patterns': [
@@ -219,7 +211,7 @@
   'rules':
     'patterns': [
       {
-        'begin': '(?:(%public|%inline)\\s*)?([a-z][a-zA-Z_]*)(?:\\s*\\(.*?\\))?(?=\\s*(:|\\|))'
+        'begin': '(?:(%public|%inline)\\s*)?([a-z][a-zA-Z0-9_]*)(?:\\s*\\(.*?\\))?(?=\\s*(:|\\|))'
         'beginCaptures':
           '1':
             'name': 'keyword.other.menhir'

--- a/grammars/menhir.cson
+++ b/grammars/menhir.cson
@@ -48,6 +48,12 @@
           '2': {'patterns': [{'include': '#uident'}]}
       }
       {
+        'match': '(%on_error_reduce)([^<>\\r\\n]+)'
+        'captures':
+          '1': {'name': 'keyword.other.directive.menhir'}
+          '2': {'patterns': [{'include': '#lident'}]}
+      }
+      {
         'begin': '%%'
         'beginCaptures':
           '0': {'name': 'keyword.other.rules.begin.menhir'}
@@ -60,25 +66,35 @@
   'rule':
     'patterns': [
       {
-        'match': '\\(([^)]+)\\)(?=\\s*:)'
+        'match': '([a-z][a-zA-Z0-9_]*)\\s*\\(([^)]+)\\)(?=\\s*:)'
         'captures':
-          '1': {'patterns': [{'include': '#ident'}]}
+          '1': {'name': 'entity.name.function.rule.menhir'}
+          '2': {'patterns': [{'include': '#ident'}]}
       }
       {
         'match': '%public|%inline'
         'name': 'keyword.other.modifier.menhir'
       }
-      {'include': '#action'}
-      {'include': '#uident'}
-      {'include': '#lident'}
+      {
+        'begin': ':|\\|'
+        'end': '(?={)'
+        'patterns': [
+          {'include': '#uident'}
+          {'include': '#lident'}
+        ]
+      }
+      {
+        'begin': '(?<![\\\'])({)'
+        'end': '(})(?:\\s*(%prec)\\s*([a-zA-Z][a-zA-Z0-9_]*))?(?![\\S]+)'
+        'endCaptures':
+          '2': {'name': 'keyword.other.prec.menhir'}
+          '3': {'name': 'entity.name.tag.token.menhir'}
+        'patterns': [{'include': 'source.ocaml'}]
+      }
     ]
-  'action':
-    'begin': '(?<![\\\'])({)'
-    'end': '(})(?!\\S+)'
-    'patterns': [{'include': 'source.ocaml'}]
   'uident':
     'match': '[A-Z][a-zA-Z0-9_]*'
-    'name': 'entity.name.tag.token.ocaml'
+    'name': 'entity.name.tag.token.menhir'
   'lident':
     'match': '[a-z][a-zA-Z0-9_]*'
     'name': 'entity.name.function.rule.menhir'

--- a/grammars/menhir.cson
+++ b/grammars/menhir.cson
@@ -2,11 +2,12 @@
 'fileTypes': ['mly']
 'scopeName': 'source.menhir'
 'patterns': [
-  { 'include': '#declaration' }
+  {'include': '#declaration'}
 ]
 'repository':
   'declaration':
     'patterns': [
+      {'include': '#comment'}
       {
         'begin': '%{'
         'beginCaptures':
@@ -79,8 +80,9 @@
         'begin': ':|\\|'
         'end': '(?={)'
         'patterns': [
-          {'include': '#uident'}
-          {'include': '#lident'}
+          {'include': '#variable'}
+          {'include': '#reference'}
+          {'include': '#operator'}
         ]
       }
       {
@@ -98,6 +100,28 @@
         'patterns': [{'include': 'source.ocaml'}]
       }
     ]
+  'comment':
+    'patterns': [
+      {
+        'begin': '/[*]'
+        'end': '[*]/'
+        'name': 'comment.block.menhir'
+      }
+    ]
+  'variable':
+    'match': '([a-z][a-zA-Z0-9_]*)\\s*='
+    'captures':
+      '1':
+        'name': 'variable.parameter.value.menhir'
+    'patterns': [{'include': '#reference'}]
+  'reference':
+    'patterns': [
+      {'include': '#uident'}
+      {'include': '#lident'}
+    ]
+  'operator':
+    'match': '[+*?]'
+    'name': 'keyword.operator.menhir'
   'uident':
     'match': '[A-Z][a-zA-Z0-9_]*'
     'name': 'entity.name.tag.token.menhir'

--- a/grammars/menhir.cson
+++ b/grammars/menhir.cson
@@ -136,7 +136,7 @@
     'name': 'keyword.operator.menhir'
   'uident':
     'match': '[A-Z][a-zA-Z0-9_]*'
-    'name': 'entity.name.tag.token.menhir'
+    'name': 'entity.name.token.menhir'
   'lident':
     'match': '[a-z][a-zA-Z0-9_]*'
     'name': 'entity.name.function.rule.menhir'

--- a/grammars/menhir.cson
+++ b/grammars/menhir.cson
@@ -66,14 +66,14 @@
   'rule':
     'patterns': [
       {
-        'match': '([a-z][a-zA-Z0-9_]*)\\s*\\(([^)]+)\\)(?=\\s*:)'
+        'match': '([a-z][a-zA-Z0-9_]*)\\s*(?:\\(([^)]+)\\))?(?=\\s*:)'
         'captures':
           '1': {'name': 'entity.name.function.rule.menhir'}
           '2': {'patterns': [{'include': '#ident'}]}
       }
       {
         'match': '%public|%inline'
-        'name': 'keyword.other.modifier.menhir'
+        'name': 'keyword.other.directive.menhir'
       }
       {
         'begin': ':|\\|'
@@ -85,10 +85,16 @@
       }
       {
         'begin': '(?<![\\\'])({)'
-        'end': '(})(?:\\s*(%prec)\\s*([a-zA-Z][a-zA-Z0-9_]*))?(?![\\S]+)'
+        'end': '(})([^\'"*]*)$'
         'endCaptures':
-          '2': {'name': 'keyword.other.prec.menhir'}
-          '3': {'name': 'entity.name.tag.token.menhir'}
+          '2':
+            'patterns': [
+              {
+                'match': '%prec\\b'
+                'name': 'keyword.other.directive.menhir'
+              }
+              {'include': '#uident'}
+            ]
         'patterns': [{'include': 'source.ocaml'}]
       }
     ]

--- a/grammars/menhir.cson
+++ b/grammars/menhir.cson
@@ -66,6 +66,7 @@
     ]
   'rule':
     'patterns': [
+      {'include': '#comment'}
       {
         'match': '([a-z][a-zA-Z0-9_]*)\\s*(?:\\(([^)]+)\\))?(?=\\s*:)'
         'captures':
@@ -106,6 +107,17 @@
         'begin': '/[*]'
         'end': '[*]/'
         'name': 'comment.block.menhir'
+      }
+      {
+        'begin': '\\(\\*'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.comment.begin.menhir'
+        'end': '\\*\\)'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.comment.end.menhir'
+        'name': 'comment.block.other.menhir'
       }
     ]
   'variable':

--- a/grammars/menhir.cson
+++ b/grammars/menhir.cson
@@ -217,7 +217,7 @@
             'name': 'keyword.other.menhir'
           '2':
             'name': 'entity.name.function.non-terminal.rule.begin.menhir'
-        'end': '(?<=})\s(?!\\|)'
+        'end': '(?<=})\\s*(?!\\|)|'
         'endCaptures':
           '0':
             'name': 'entity.name.function.non-terminal.rule.end.menhir'

--- a/grammars/menhir.cson
+++ b/grammars/menhir.cson
@@ -1,258 +1,87 @@
-'fileTypes': [
-  'mly'
-]
-'foldingStartMarker': '%{|%%'
-'foldingStopMarker': '%}|%%'
 'name': 'Menhir'
+'fileTypes': ['mly']
+'scopeName': 'source.menhir'
 'patterns': [
-  {
-    'begin': '(%{)\\s*$'
-    'beginCaptures':
-      '1':
-        'name': 'keyword.operator.header.begin.menhir'
-    'end': '^\\s*(%})'
-    'endCaptures':
-      '1':
-        'name': 'keyword.operator.header.end.menhir'
-    'name': 'meta.header.menhir'
-    'patterns': [{ 'include': 'source.ocaml' }]
-  }
-  {
-    'begin': '(?<=%})\\s*$'
-    'end': '(?:^)(?=%%)'
-    'name': 'meta.declarations.menhir'
-    'patterns': [
-      { 'include': '#comments' }
-      { 'include': '#declaration-matches' }
-    ]
-  }
-  {
-    'begin': '(%%)\\s*$'
-    'beginCaptures':
-      '1':
-        'name': 'keyword.operator.rules.begin.menhir'
-    'end': '^\\s*(%%)'
-    'endCaptures':
-      '1':
-        'name': 'keyword.operator.rules.end.menhir'
-    'name': 'meta.rules.menhir'
-    'patterns': [
-      { 'include': '#comments' }
-      { 'include': '#rules' }
-    ]
-  }
-  { 'include': 'source.ocaml' }
-  { 'include': '#comments' }
-  {
-    'match': '(’|‘|“|”)'
-    'name': 'invalid.illegal.unrecognized-character.ocaml'
-  }
+  { 'include': '#declaration' }
 ]
 'repository':
-  'comments':
+  'declaration':
     'patterns': [
       {
-        'begin': '/\\*'
-        'end': '\\*/'
-        'name': 'comment.block.menhir'
-        'patterns': [{ 'include': '#comments' }]
-      }
-      {
-        'begin': '\\(\\*'
+        'begin': '%{'
         'beginCaptures':
-          '0':
-            'name': 'punctuation.definition.comment.begin.menhir'
-        'end': '\\*\\)'
+          '0': {'name': 'keyword.other.code.begin.menhir'}
+        'end': '%}'
         'endCaptures':
-          '0':
-            'name': 'punctuation.definition.comment.end.menhir'
-        'name': 'comment.block.other.menhir'
-        'patterns': [{ 'include': '#comments' }]
+          '0': {'name': 'keyword.other.code.end.menhir'}
+        'patterns': [{'include': 'source.ocaml'}]
       }
       {
-        'begin': '(?=[^\\\\])(")'
-        'end': '"'
-        'name': 'comment.block.string.quoted.double.menhir'
-        'patterns': [
-          {
-            'match': '\\\\(x[a-fA-F0-9][a-fA-F0-9]|[0-2]\\d\\d|[bnrt\'"\\\\])'
-            'name': 'comment.block.string.constant.character.escape.menhir'
-          }
-        ]
-      }
-    ]
-  'declaration-matches':
-    'patterns': [
-      {
-        'begin': '%token'
+        'begin': '(%parameter)\\s*(<)'
         'beginCaptures':
-          '0':
-            'name': 'keyword.other.directive.token.menhir'
-        'end': '^\\s*($|(^\\s*(?=%)))'
-        'name': 'meta.token.declaration.menhir'
-        'patterns': [
-          { 'include': '#symbol-types' }
-          {
-            'match': '[A-Z][A-Za-z0-9_]*'
-            'name': 'entity.name.type.token.menhir'
-          }
-          { 'include': '#comments' }
-        ]
+          '1': {'name': 'keyword.other.directive.menhir'}
+        'end': '(>)'
+        'patterns': [{'include': 'source.ocaml'}]
       }
       {
-        'begin': '%left|%right|%nonassoc'
+        'begin': '(%start|%type)\\s*(<)'
         'beginCaptures':
-          '0':
-            'name': 'keyword.other.directive.token.associativity.menhir'
-        'end': '(^\\s*$)|(^\\s*(?=%))'
-        'name': 'meta.token.associativity.menhir'
-        'patterns': [
-          {
-            'match': '[A-Z][A-Za-z0-9_]*'
-            'name': 'entity.name.type.token.menhir'
-          }
-          {
-            'match': '[a-z][A-Za-z0-9_]*'
-            'name': 'entity.name.function.non-terminal.reference.menhir'
-          }
-          { 'include': '#comments' }
-        ]
+          '1': {'name': 'keyword.other.directive.menhir'}
+        'end': '(>)([^\\r\\n]+)'
+        'endCaptures':
+          '2': {'patterns': [{'include': '#lident'}]}
+        'patterns': [{'include': 'source.ocaml#typedefs'}]
       }
       {
-        'begin': '%start'
+        'begin': '(%token)\\s*(<)'
         'beginCaptures':
-          '0':
-            'name': 'keyword.other.directive.start-symbol.menhir'
-        'end': '^\\s*($|(^\\s*(?=%)))'
-        'name': 'meta.start-symbol.menhir'
-        'patterns': [
-          { 'include': '#symbol-types'}
-          {
-            'match': '[a-z][A-Za-z0-9_]*'
-            'name': 'entity.name.function.non-terminal.reference.menhir'
-          }
-          { 'include': '#comments' }
-        ]
+          '1': {'name': 'keyword.other.directive.menhir'}
+        'end': '(>)([^\\r\\n]+)'
+        'endCaptures':
+          '2': {'patterns': [{'include': '#uident'}]}
+        'patterns': [{'include': 'source.ocaml#typedefs'}]
       }
       {
-        'begin': '%type'
-        'beginCaptures':
-          '0':
-            'name': 'keyword.other.directive.type.menhir'
-        'end': '$\\s*(?!%)'
-        'name': 'meta.symbol-type.menhir'
-        'patterns': [
-          { 'include': '#symbol-types' }
-          {
-            'match': '[A-Z][A-Za-z0-9_]*'
-            'name': 'entity.name.type.token.reference.menhir'
-          }
-          {
-            'match': '[a-z][A-Za-z0-9_]*'
-            'name': 'entity.name.function.non-terminal.reference.menhir'
-          }
-          { 'include': '#comments' }
-        ]
-      }
-    ]
-  'precs':
-    'patterns': [
-      {
+        'match': '(%token|%nonassoc|%left|%right)([^<>\\r\\n]+)'
         'captures':
-          '1':
-            'name': 'keyword.other.decorator.precedence.menhir'
-          '2':
-            'name': 'keyword.other.precedence.menhir'
-          '4':
-            'name': 'entity.name.function.non-terminal.reference.menhir'
-          '5':
-            'name': 'entity.name.type.token.reference.menhir'
-        'match': '(%)(prec)\\s+(([a-z][a-zA-Z0-9_]*)|(([A-Z][a-zA-Z0-9_]*)))'
-        'name': 'meta.precedence.declaration'
+          '1': {'name': 'keyword.other.directive.menhir'}
+          '2': {'patterns': [{'include': '#uident'}]}
+      }
+      {
+        'begin': '%%'
+        'beginCaptures':
+          '0': {'name': 'keyword.other.rules.begin.menhir'}
+        'end': '%%'
+        'endCaptures':
+          '0': {'name': 'keyword.other.rules.end.menhir'}
+        'patterns': [{'include': '#rule'}]
       }
     ]
-  'variables':
+  'rule':
     'patterns': [
       {
-        'match': '([a-z][A-Za-z0-9_]*)\\s*='
+        'match': '\\(([^)]+)\\)(?=\\s*:)'
         'captures':
-          '1':
-            'name': 'variable.parameter.menhir'
-        'name': 'meta.assignment.menhir'
-        'patterns': [{ 'include': '#references' }]
-      }
-    ]
-  'references':
-    'patterns': [
-      {
-        'match': '[a-z][a-zA-Z0-9_]*'
-        'name': 'entity.name.function.non-terminal.reference.menhir'
+          '1': {'patterns': [{'include': '#ident'}]}
       }
       {
-        'match': '[A-Z][a-zA-Z0-9_]*'
-        'name': 'entity.name.type.token.reference.menhir'
+        'match': '%public|%inline'
+        'name': 'keyword.other.modifier.menhir'
       }
+      {'include': '#action'}
+      {'include': '#uident'}
+      {'include': '#lident'}
     ]
-  'rule-patterns':
-    'patterns': [
-      {
-        'begin': '((?<!\\|)(\\|)(?!:))'
-        'end': '(?<=})\s'
-        'name': 'meta.rule-pattern.menhir'
-        'patterns': [
-          { 'include': '#precs' }
-          { 'include': '#semantic-actions' }
-          { 'include': '#variables' }
-          { 'include': '#references' }
-          { 'include': '#comments' }
-        ]
-      }
-    ]
-  'rules':
-    'patterns': [
-      {
-        'begin': '(?:(%public|%inline)\\s*)?([a-z][a-zA-Z0-9_]*)(?:\\s*\\(.*?\\))?(?=\\s*(:|\\|))'
-        'beginCaptures':
-          '1':
-            'name': 'keyword.other.menhir'
-          '2':
-            'name': 'entity.name.function.non-terminal.rule.begin.menhir'
-        'end': '(?=[^{}]+:)'
-        'endCaptures':
-          '0':
-            'name': 'entity.name.function.non-terminal.rule.end.menhir'
-        'name': 'meta.non-terminal.rule.menhir'
-        'patterns': [{ 'include': '#rule-patterns' }]
-      }
-    ]
-  'semantic-actions':
-    'patterns': [
-      {
-        'begin': '[^\\\']({)'
-        'beginCaptures':
-          '1':
-            'name': 'punctuation.definition.action.semantic.begin.menhir'
-        'end': '(})'
-        'endCaptures':
-          '1':
-            'name': 'punctuation.definition.action.semantic.end.menhir'
-        'name': 'meta.action.semantic.menhir'
-        'patterns': [{ 'include': 'source.ocaml' }]
-      }
-    ]
-  'symbol-types':
-    'patterns': [
-      {
-        'begin': '<'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.definition.type-declaration.begin.menhir'
-        'end': '>'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.definition.type-declaration.end.menhir'
-        'name': 'meta.token.type-declaration.menhir'
-        'patterns': [{ 'include': 'source.ocaml' }]
-      }
-    ]
-'scopeName': 'source.menhir'
+  'action':
+    'begin': '(?<![\\\'])({)'
+    'end': '(})(?!\\S+)'
+    'patterns': [{'include': 'source.ocaml'}]
+  'uident':
+    'match': '[A-Z][a-zA-Z0-9_]*'
+    'name': 'entity.name.tag.token.ocaml'
+  'lident':
+    'match': '[a-z][a-zA-Z0-9_]*'
+    'name': 'entity.name.function.rule.menhir'
+  'ident':
+    'match': '[a-zA-Z][a-zA-Z0-9_]*'
+    'name': 'variable.parameter.rule.menhir'

--- a/grammars/ocaml.cson
+++ b/grammars/ocaml.cson
@@ -620,7 +620,7 @@
     'name': 'keyword.control.ocaml'
   }
   {
-    'match': '\\b(as|assert|class|constraint|exception|functor|in|include|inherit|initializer|lazy|let|mod|module|mutable|new|object|open|private|rec|sig|struct|type|virtual)\\b'
+    'match': '\\b(as|assert|class|constraint|exception|functor|in|include|inherit|initializer|lazy|let|mod|module|mutable|new|object|open|private|rec|raise|sig|struct|type|virtual)\\b'
     'name': 'keyword.other.ocaml'
   }
   {

--- a/grammars/ocaml.cson
+++ b/grammars/ocaml.cson
@@ -410,7 +410,9 @@
         'name': 'keyword.other.ocaml'
       '2':
         'name': 'entity.name.type.exception.ocaml'
-    'match': '\\b(exception)\\s+([A-Z][a-zA-Z0-9\'_]*)\\b'
+      '3':
+        'name': 'keyword.other.ocaml'
+    'match': '\\b(exception)\\s+([A-Z][a-zA-Z0-9\'_]*)(?:\\s+(of))?\\b'
     'name': 'meta.exception.ocaml'
   }
   {

--- a/grammars/ocamllex.cson
+++ b/grammars/ocamllex.cson
@@ -37,7 +37,7 @@
     ]
   }
   {
-    'begin': '(rule|and)\\s+([a-z][a-zA-Z0-9_]*)\\s+(=)\\s+(parse)(?=\\s*$)|((?<!\\|)(\\|)(?!\\|))'
+    'begin': '(rule|and)\\s+([a-z][a-zA-Z0-9_]*)(?:\\s+(?:[a-z][a-zA-Z0-9_]*))*\\s+(=)\\s+(parse)(?=\\s*$)|((?<!\\|)(\\|)(?!\\|))'
     'beginCaptures':
       '1':
         'name': 'keyword.other.ocamllex'
@@ -169,10 +169,6 @@
         ]
       }
       {
-        'match': '[a-z][a-zA-Z0-9\'_]'
-        'name': 'entity.name.type.pattern.reference.stupid-goddamn-hack.ocamllex'
-      }
-      {
         'match': '\\bas\\b'
         'name': 'keyword.other.pattern.ocamllex'
       }
@@ -183,6 +179,10 @@
       {
         'match': '_'
         'name': 'constant.language.universal-match.ocamllex'
+      }
+      {
+        'match': '[a-z][a-zA-Z0-9\'_]'
+        'name': 'entity.name.type.pattern.reference.stupid-goddamn-hack.ocamllex'
       }
       {
         'begin': '(\\[)(\\^?)'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/hackwaly/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/hackwaly/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/hackwaly/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/hackwaly/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/hackwaly/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/hackwaly/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/hackwaly/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/hackwaly/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/hackwaly/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/hackwaly/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "language-ocaml",
+  "name": "language-ocaml-fix",
   "version": "1.1.3",
   "private": true,
   "description": "Syntax support for the OCaml language",
-  "repository": "https://github.com/toroidal-code/language-ocaml",
+  "repository": "https://github.com/hackwaly/language-ocaml-fix",
   "license": "MIT",
   "engines": {
     "atom": ">0.50.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/hackwaly/language-ocaml-fix",


### PR DESCRIPTION
bug 1: lex rules with arguments are not highlighted correctly.
bug 2: ocamllex specific `as`, `eof` keywords are not highlighted correctly. 
