### PR TITLE
Merge language-ocaml-fix upstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,42 @@
+### Project specific config ###
+language: generic
+
+env:
+  global:
+    - APM_TEST_PACKAGES=""
+
+  matrix:
+    - ATOM_CHANNEL=stable
+    - ATOM_CHANNEL=beta
+
+os:
+  - linux
+  - osx
+
+### Generic setup follows ### 
+script:
+  - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
+  - chmod u+x build-package.sh
+  - ./build-package.sh
+
+notifications:
+  email:
+    on_success: never
+    on_failure: change
+
+branches:
+  only:
+    - master
+
+git:
+  depth: 10
+
+sudo: false
+
+addons:
+  apt:
+    packages:
+    - build-essential
+    - git
+    - libgnome-keyring-dev
+    - fakeroot

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/AndreasDahl/language-ocaml-fix.svg?branch=master)](https://travis-ci.org/AndreasDahl/language-ocaml-fix)
 
-** This package is a fork of inactive package [language-ocaml](https://github.com/toroidal-code/language-ocaml) **
+**This package is a fork of inactive package [language-ocaml](https://github.com/toroidal-code/language-ocaml)**
 
 Adds syntax highlighting to OCaml files in Atom.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://travis-ci.org/AndreasDahl/language-ocaml-fix.svg?branch=master)](https://travis-ci.org/AndreasDahl/language-ocaml-fix)
 
+** This package is a fork of inactive package [language-ocaml](https://github.com/toroidal-code/language-ocaml) **
+
 Adds syntax highlighting to OCaml files in Atom.
 
 Originally [converted](https://atom.io/docs/latest/converting-a-text-mate-bundle) from the [OCaml TextMate bundle](https://github.com/textmate/ocaml.tmbundle).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # OCaml Atom package
+
+[![Build Status](https://travis-ci.org/AndreasDahl/language-ocaml-fix.svg?branch=master)](https://travis-ci.org/AndreasDahl/language-ocaml-fix)
+
 Adds syntax highlighting to OCaml files in Atom.
 
 Originally [converted](https://atom.io/docs/latest/converting-a-text-mate-bundle) from the [OCaml TextMate bundle](https://github.com/textmate/ocaml.tmbundle).

--- a/grammars/menhir.cson
+++ b/grammars/menhir.cson
@@ -219,14 +219,16 @@
   'rules':
     'patterns': [
       {
-        'begin': '([a-z][a-zA-Z_]*)(?>\\s*(:|\\|))'
+        'begin': '(?:(%public|%inline)\\s*)?([a-z][a-zA-Z_]*)(?:\\s*\\(.*?\\))?(?=\\s*(:|\\|))'
         'beginCaptures':
           '1':
+            'name': 'keyword.other.menhir'
+          '2':
             'name': 'entity.name.function.non-terminal.rule.begin.menhir'
         'end': '(?<=})\s(?!\\|)'
         'endCaptures':
           '0':
-            'name': 'entity.name.function.non-terminal.rule.end.menhir'        
+            'name': 'entity.name.function.non-terminal.rule.end.menhir'
         'name': 'meta.non-terminal.rule.menhir'
         'patterns': [{ 'include': '#rule-patterns' }]
       }

--- a/grammars/menhir.cson
+++ b/grammars/menhir.cson
@@ -2,7 +2,21 @@
 'fileTypes': ['mly']
 'scopeName': 'source.menhir'
 'patterns': [
-  {'include': '#declaration'}
+  {
+    'begin': '(?=%[^%])'
+    'end': '(?=%%)'
+    'patterns': [{'include': '#declaration'}]
+  }
+  {
+    'begin': '%%'
+    'beginCaptures':
+      '0': {'name': 'keyword.other.rules.begin.menhir'}
+    'end': '%%'
+    'endCaptures':
+      '0': {'name': 'keyword.other.rules.end.menhir'}
+    'patterns': [{'include': '#rule'}]
+  }
+  {'include': 'source.ocaml'}
 ]
 'repository':
   'declaration':
@@ -53,15 +67,6 @@
         'captures':
           '1': {'name': 'keyword.other.directive.menhir'}
           '2': {'patterns': [{'include': '#lident'}]}
-      }
-      {
-        'begin': '%%'
-        'beginCaptures':
-          '0': {'name': 'keyword.other.rules.begin.menhir'}
-        'end': '%%'
-        'endCaptures':
-          '0': {'name': 'keyword.other.rules.end.menhir'}
-        'patterns': [{'include': '#rule'}]
       }
     ]
   'rule':

--- a/grammars/menhir.cson
+++ b/grammars/menhir.cson
@@ -2,76 +2,68 @@
 'fileTypes': ['mly']
 'scopeName': 'source.menhir'
 'patterns': [
+  {'include': '#comment'}
   {
     'begin': '(?=%[^%])'
     'end': '(?=%%)'
-    'patterns': [{'include': '#declaration'}]
+    'patterns': [
+      {'include': '#comment'}
+      {'include': '#declaration'}
+    ]
   }
   {
     'begin': '%%'
     'beginCaptures':
-      '0': {'name': 'keyword.other.rules.begin.menhir'}
+      '0': {'name': 'keyword.other.menhir'}
     'end': '%%'
     'endCaptures':
-      '0': {'name': 'keyword.other.rules.end.menhir'}
-    'patterns': [{'include': '#rule'}]
+      '0': {'name': 'keyword.other.menhir'}
+    'patterns': [
+      {'include': '#comment'}
+      {'include': '#rule'}
+    ]
   }
   {'include': 'source.ocaml'}
 ]
 'repository':
   'declaration':
     'patterns': [
-      {'include': '#comment'}
       {
         'begin': '%{'
         'beginCaptures':
-          '0': {'name': 'keyword.other.code.begin.menhir'}
+          '0': {'name': 'keyword.other.menhir'}
         'end': '%}'
         'endCaptures':
-          '0': {'name': 'keyword.other.code.end.menhir'}
+          '0': {'name': 'keyword.other.menhir'}
         'patterns': [{'include': 'source.ocaml'}]
       }
       {
-        'begin': '(%parameter)\\s*(<)'
+        'match': '(%parameter|%start|%type|%token|%nonassoc|%left|%right|%on_error_reduce)\\b'
+        'name': 'keyword.other.menhir'
+      }
+      {
+        'begin': '(<)\\s*([a-zA-Z][a-zA-Z0-9_]*)\\s*(:)'
         'beginCaptures':
-          '1': {'name': 'keyword.other.directive.menhir'}
+          '1': {'name': 'keyword.other.menhir'}
+          '2': {'name': 'variable.parameter.module.menhir'}
+          '3': {'name': 'keyword.other.menhir'}
         'end': '(>)'
+        'endCaptures':
+          '1': {'name': 'keyword.other.menhir'}
         'patterns': [{'include': 'source.ocaml'}]
       }
       {
-        'begin': '(%start|%type)\\s*(<)'
+        'begin': '(<)'
         'beginCaptures':
-          '1': {'name': 'keyword.other.directive.menhir'}
-        'end': '(>)([^\\r\\n]+)'
+          '1': {'name': 'keyword.other.menhir'}
+        'end': '(>)'
         'endCaptures':
-          '2': {'patterns': [{'include': '#lident'}]}
+          '1': {'name': 'keyword.other.menhir'}
         'patterns': [{'include': 'source.ocaml#typedefs'}]
-      }
-      {
-        'begin': '(%token)\\s*(<)'
-        'beginCaptures':
-          '1': {'name': 'keyword.other.directive.menhir'}
-        'end': '(>)([^\\r\\n]+)'
-        'endCaptures':
-          '2': {'patterns': [{'include': '#uident'}]}
-        'patterns': [{'include': 'source.ocaml#typedefs'}]
-      }
-      {
-        'match': '(%token|%nonassoc|%left|%right)([^<>\\r\\n]+)'
-        'captures':
-          '1': {'name': 'keyword.other.directive.menhir'}
-          '2': {'patterns': [{'include': '#uident'}]}
-      }
-      {
-        'match': '(%on_error_reduce)([^<>\\r\\n]+)'
-        'captures':
-          '1': {'name': 'keyword.other.directive.menhir'}
-          '2': {'patterns': [{'include': '#lident'}]}
       }
     ]
   'rule':
     'patterns': [
-      {'include': '#comment'}
       {
         'match': '([a-z][a-zA-Z0-9_]*)\\s*(?:\\(([^)]+)\\))?(?=\\s*:)'
         'captures':
@@ -79,49 +71,41 @@
           '2': {'patterns': [{'include': '#ident'}]}
       }
       {
-        'match': '%public|%inline'
+        'match': '%public|%inline|%prec'
         'name': 'keyword.other.directive.menhir'
       }
       {
-        'begin': ':|\\|'
+        'begin': '(:|\\|)'
+        'beginCaptures':
+          '1': {'name': 'keyword.other.menhir'}
         'end': '(?={)'
         'patterns': [
+          {'include': '#comment'}
           {'include': '#variable'}
           {'include': '#reference'}
           {'include': '#operator'}
         ]
       }
       {
-        'begin': '(?<![\\\'])({)'
-        'end': '(})([^\'"*]*)$'
+        'begin': '({)'
+        'beginCaptures':
+          '1': {'name': 'keyword.other.menhir'}
+        'end': '(})'
         'endCaptures':
-          '2':
-            'patterns': [
-              {
-                'match': '%prec\\b'
-                'name': 'keyword.other.directive.menhir'
-              }
-              {'include': '#uident'}
-            ]
+          '1': {'name': 'keyword.other.menhir'}
         'patterns': [{'include': 'source.ocaml'}]
       }
     ]
   'comment':
     'patterns': [
       {
-        'begin': '/[*]'
-        'end': '[*]/'
+        'begin': '/\\*'
+        'end': '\\*/'
         'name': 'comment.block.menhir'
       }
       {
         'begin': '\\(\\*'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.definition.comment.begin.menhir'
         'end': '\\*\\)'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.definition.comment.end.menhir'
         'name': 'comment.block.other.menhir'
       }
     ]
@@ -141,7 +125,7 @@
       {'include': '#lident'}
     ]
   'operator':
-    'match': '[+*?]'
+    'match': '[+*?|]'
     'name': 'keyword.operator.menhir'
   'uident':
     'match': '[A-Z][a-zA-Z0-9_]*'

--- a/grammars/menhir.cson
+++ b/grammars/menhir.cson
@@ -217,7 +217,7 @@
             'name': 'keyword.other.menhir'
           '2':
             'name': 'entity.name.function.non-terminal.rule.begin.menhir'
-        'end': '(?<=})\\s*(?!\\|)|'
+        'end': '(?=[^{}]+:)'
         'endCaptures':
           '0':
             'name': 'entity.name.function.non-terminal.rule.end.menhir'

--- a/grammars/menhir.cson
+++ b/grammars/menhir.cson
@@ -128,6 +128,10 @@
     'patterns': [{'include': '#reference'}]
   'reference':
     'patterns': [
+      {
+        'match': '\\b(?:[ibl]?option|pair|separated_pair|preceded|terminated|delimited|list|nonempty_list|separated_list|separated_nonempty_list)\\b',
+        'name': 'support.function.rule.menhir'
+      }
       {'include': '#uident'}
       {'include': '#lident'}
     ]

--- a/grammars/menhir.cson
+++ b/grammars/menhir.cson
@@ -9,11 +9,11 @@
     'begin': '(%{)\\s*$'
     'beginCaptures':
       '1':
-        'name': 'punctuation.section.header.begin.menhir'
+        'name': 'keyword.operator.header.begin.menhir'
     'end': '^\\s*(%})'
     'endCaptures':
       '1':
-        'name': 'punctuation.section.header.end.menhir'
+        'name': 'keyword.operator.header.end.menhir'
     'name': 'meta.header.menhir'
     'patterns': [{ 'include': 'source.ocaml' }]
   }
@@ -30,11 +30,11 @@
     'begin': '(%%)\\s*$'
     'beginCaptures':
       '1':
-        'name': 'punctuation.section.rules.begin.menhir'
+        'name': 'keyword.operator.rules.begin.menhir'
     'end': '^\\s*(%%)'
     'endCaptures':
       '1':
-        'name': 'punctuation.section.rules.end.menhir'
+        'name': 'keyword.operator.rules.end.menhir'
     'name': 'meta.rules.menhir'
     'patterns': [
       { 'include': '#comments' }
@@ -84,12 +84,10 @@
   'declaration-matches':
     'patterns': [
       {
-        'begin': '(%)(token)'
+        'begin': '%token'
         'beginCaptures':
-          '1':
-            'name': 'keyword.other.decorator.token.menhir'
-          '2':
-            'name': 'keyword.other.token.menhir'
+          '0':
+            'name': 'keyword.other.directive.token.menhir'
         'end': '^\\s*($|(^\\s*(?=%)))'
         'name': 'meta.token.declaration.menhir'
         'patterns': [
@@ -102,12 +100,10 @@
         ]
       }
       {
-        'begin': '(%)(left|right|nonassoc)'
+        'begin': '%left|%right|%nonassoc'
         'beginCaptures':
-          '1':
-            'name': 'keyword.other.decorator.token.associativity.menhir'
-          '2':
-            'name': 'keyword.other.token.associativity.menhir'
+          '0':
+            'name': 'keyword.other.directive.token.associativity.menhir'
         'end': '(^\\s*$)|(^\\s*(?=%))'
         'name': 'meta.token.associativity.menhir'
         'patterns': [
@@ -123,12 +119,10 @@
         ]
       }
       {
-        'begin': '(%)(start)'
+        'begin': '%start'
         'beginCaptures':
-          '1':
-            'name': 'keyword.other.decorator.start-symbol.menhir'
-          '2':
-            'name': 'keyword.other.start-symbol.menhir'
+          '0':
+            'name': 'keyword.other.directive.start-symbol.menhir'
         'end': '^\\s*($|(^\\s*(?=%)))'
         'name': 'meta.start-symbol.menhir'
         'patterns': [
@@ -141,12 +135,10 @@
         ]
       }
       {
-        'begin': '(%)(type)'
+        'begin': '%type'
         'beginCaptures':
-          '1':
-            'name': 'keyword.other.decorator.symbol-type.menhir'
-          '2':
-            'name': 'keyword.other.symbol-type.menhir'
+          '0':
+            'name': 'keyword.other.directive.type.menhir'
         'end': '$\\s*(?!%)'
         'name': 'meta.symbol-type.menhir'
         'patterns': [
@@ -219,7 +211,7 @@
   'rules':
     'patterns': [
       {
-        'begin': '(?:(%public|%inline)\\s*)?([a-z][a-zA-Z_]*)(?:\\s*\\(.*?\\))?(?=\\s*(:|\\|))'
+        'begin': '(?:(%public|%inline)\\s*)?([a-z][a-zA-Z0-9_]*)(?:\\s*\\(.*?\\))?(?=\\s*(:|\\|))'
         'beginCaptures':
           '1':
             'name': 'keyword.other.menhir'

--- a/grammars/menhir.cson
+++ b/grammars/menhir.cson
@@ -48,6 +48,12 @@
           '2': {'patterns': [{'include': '#uident'}]}
       }
       {
+        'match': '(%on_error_reduce)([^<>\\r\\n]+)'
+        'captures':
+          '1': {'name': 'keyword.other.directive.menhir'}
+          '2': {'patterns': [{'include': '#lident'}]}
+      }
+      {
         'begin': '%%'
         'beginCaptures':
           '0': {'name': 'keyword.other.rules.begin.menhir'}
@@ -60,25 +66,35 @@
   'rule':
     'patterns': [
       {
-        'match': '\\(([^)]+)\\)(?=\\s*:)'
+        'match': '([a-z][a-zA-Z0-9_]*)\\s*\\(([^)]+)\\)(?=\\s*:)'
         'captures':
-          '1': {'patterns': [{'include': '#ident'}]}
+          '1': {'name': 'entity.name.function.rule.menhir'}
+          '2': {'patterns': [{'include': '#ident'}]}
       }
       {
         'match': '%public|%inline'
         'name': 'keyword.other.modifier.menhir'
       }
-      {'include': '#action'}
-      {'include': '#uident'}
-      {'include': '#lident'}
+      {
+        'begin': ':|\\|'
+        'end': '(?={)'
+        'patterns': [
+          {'include': '#uident'}
+          {'include': '#lident'}
+        ]
+      }
+      {
+        'begin': '(?<![\\\'])({)'
+        'end': '(})(?:\\s*(%prec)\\s*([a-zA-Z][a-zA-Z0-9_]*))?(?![\\S]+)'
+        'endCaptures':
+          '2': {'name': 'keyword.other.prec.menhir'}
+          '3': {'name': 'entity.name.tag.token.menhir'}
+        'patterns': [{'include': 'source.ocaml'}]
+      }
     ]
-  'action':
-    'begin': '(?<![\\\'])({)'
-    'end': '(})(?!\\S+)'
-    'patterns': [{'include': 'source.ocaml'}]
   'uident':
     'match': '[A-Z][a-zA-Z0-9_]*'
-    'name': 'entity.name.tag.token.ocaml'
+    'name': 'entity.name.tag.token.menhir'
   'lident':
     'match': '[a-z][a-zA-Z0-9_]*'
     'name': 'entity.name.function.rule.menhir'

--- a/grammars/menhir.cson
+++ b/grammars/menhir.cson
@@ -2,11 +2,12 @@
 'fileTypes': ['mly']
 'scopeName': 'source.menhir'
 'patterns': [
-  { 'include': '#declaration' }
+  {'include': '#declaration'}
 ]
 'repository':
   'declaration':
     'patterns': [
+      {'include': '#comment'}
       {
         'begin': '%{'
         'beginCaptures':
@@ -79,8 +80,9 @@
         'begin': ':|\\|'
         'end': '(?={)'
         'patterns': [
-          {'include': '#uident'}
-          {'include': '#lident'}
+          {'include': '#variable'}
+          {'include': '#reference'}
+          {'include': '#operator'}
         ]
       }
       {
@@ -98,6 +100,28 @@
         'patterns': [{'include': 'source.ocaml'}]
       }
     ]
+  'comment':
+    'patterns': [
+      {
+        'begin': '/[*]'
+        'end': '[*]/'
+        'name': 'comment.block.menhir'
+      }
+    ]
+  'variable':
+    'match': '([a-z][a-zA-Z0-9_]*)\\s*='
+    'captures':
+      '1':
+        'name': 'variable.parameter.value.menhir'
+    'patterns': [{'include': '#reference'}]
+  'reference':
+    'patterns': [
+      {'include': '#uident'}
+      {'include': '#lident'}
+    ]
+  'operator':
+    'match': '[+*?]'
+    'name': 'keyword.operator.menhir'
   'uident':
     'match': '[A-Z][a-zA-Z0-9_]*'
     'name': 'entity.name.tag.token.menhir'

--- a/grammars/menhir.cson
+++ b/grammars/menhir.cson
@@ -136,7 +136,7 @@
     'name': 'keyword.operator.menhir'
   'uident':
     'match': '[A-Z][a-zA-Z0-9_]*'
-    'name': 'entity.name.tag.token.menhir'
+    'name': 'entity.name.token.menhir'
   'lident':
     'match': '[a-z][a-zA-Z0-9_]*'
     'name': 'entity.name.function.rule.menhir'

--- a/grammars/menhir.cson
+++ b/grammars/menhir.cson
@@ -66,14 +66,14 @@
   'rule':
     'patterns': [
       {
-        'match': '([a-z][a-zA-Z0-9_]*)\\s*\\(([^)]+)\\)(?=\\s*:)'
+        'match': '([a-z][a-zA-Z0-9_]*)\\s*(?:\\(([^)]+)\\))?(?=\\s*:)'
         'captures':
           '1': {'name': 'entity.name.function.rule.menhir'}
           '2': {'patterns': [{'include': '#ident'}]}
       }
       {
         'match': '%public|%inline'
-        'name': 'keyword.other.modifier.menhir'
+        'name': 'keyword.other.directive.menhir'
       }
       {
         'begin': ':|\\|'
@@ -85,10 +85,16 @@
       }
       {
         'begin': '(?<![\\\'])({)'
-        'end': '(})(?:\\s*(%prec)\\s*([a-zA-Z][a-zA-Z0-9_]*))?(?![\\S]+)'
+        'end': '(})([^\'"*]*)$'
         'endCaptures':
-          '2': {'name': 'keyword.other.prec.menhir'}
-          '3': {'name': 'entity.name.tag.token.menhir'}
+          '2':
+            'patterns': [
+              {
+                'match': '%prec\\b'
+                'name': 'keyword.other.directive.menhir'
+              }
+              {'include': '#uident'}
+            ]
         'patterns': [{'include': 'source.ocaml'}]
       }
     ]

--- a/grammars/menhir.cson
+++ b/grammars/menhir.cson
@@ -66,6 +66,7 @@
     ]
   'rule':
     'patterns': [
+      {'include': '#comment'}
       {
         'match': '([a-z][a-zA-Z0-9_]*)\\s*(?:\\(([^)]+)\\))?(?=\\s*:)'
         'captures':
@@ -106,6 +107,17 @@
         'begin': '/[*]'
         'end': '[*]/'
         'name': 'comment.block.menhir'
+      }
+      {
+        'begin': '\\(\\*'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.comment.begin.menhir'
+        'end': '\\*\\)'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.comment.end.menhir'
+        'name': 'comment.block.other.menhir'
       }
     ]
   'variable':

--- a/grammars/menhir.cson
+++ b/grammars/menhir.cson
@@ -217,7 +217,7 @@
             'name': 'keyword.other.menhir'
           '2':
             'name': 'entity.name.function.non-terminal.rule.begin.menhir'
-        'end': '(?<=})\s(?!\\|)'
+        'end': '(?<=})\\s*(?!\\|)|'
         'endCaptures':
           '0':
             'name': 'entity.name.function.non-terminal.rule.end.menhir'

--- a/grammars/menhir.cson
+++ b/grammars/menhir.cson
@@ -1,258 +1,87 @@
-'fileTypes': [
-  'mly'
-]
-'foldingStartMarker': '%{|%%'
-'foldingStopMarker': '%}|%%'
 'name': 'Menhir'
+'fileTypes': ['mly']
+'scopeName': 'source.menhir'
 'patterns': [
-  {
-    'begin': '(%{)\\s*$'
-    'beginCaptures':
-      '1':
-        'name': 'keyword.operator.header.begin.menhir'
-    'end': '^\\s*(%})'
-    'endCaptures':
-      '1':
-        'name': 'keyword.operator.header.end.menhir'
-    'name': 'meta.header.menhir'
-    'patterns': [{ 'include': 'source.ocaml' }]
-  }
-  {
-    'begin': '(?<=%})\\s*$'
-    'end': '(?:^)(?=%%)'
-    'name': 'meta.declarations.menhir'
-    'patterns': [
-      { 'include': '#comments' }
-      { 'include': '#declaration-matches' }
-    ]
-  }
-  {
-    'begin': '(%%)\\s*$'
-    'beginCaptures':
-      '1':
-        'name': 'keyword.operator.rules.begin.menhir'
-    'end': '^\\s*(%%)'
-    'endCaptures':
-      '1':
-        'name': 'keyword.operator.rules.end.menhir'
-    'name': 'meta.rules.menhir'
-    'patterns': [
-      { 'include': '#comments' }
-      { 'include': '#rules' }
-    ]
-  }
-  { 'include': 'source.ocaml' }
-  { 'include': '#comments' }
-  {
-    'match': '(’|‘|“|”)'
-    'name': 'invalid.illegal.unrecognized-character.ocaml'
-  }
+  { 'include': '#declaration' }
 ]
 'repository':
-  'comments':
+  'declaration':
     'patterns': [
       {
-        'begin': '/\\*'
-        'end': '\\*/'
-        'name': 'comment.block.menhir'
-        'patterns': [{ 'include': '#comments' }]
-      }
-      {
-        'begin': '\\(\\*'
+        'begin': '%{'
         'beginCaptures':
-          '0':
-            'name': 'punctuation.definition.comment.begin.menhir'
-        'end': '\\*\\)'
+          '0': {'name': 'keyword.other.code.begin.menhir'}
+        'end': '%}'
         'endCaptures':
-          '0':
-            'name': 'punctuation.definition.comment.end.menhir'
-        'name': 'comment.block.other.menhir'
-        'patterns': [{ 'include': '#comments' }]
+          '0': {'name': 'keyword.other.code.end.menhir'}
+        'patterns': [{'include': 'source.ocaml'}]
       }
       {
-        'begin': '(?=[^\\\\])(")'
-        'end': '"'
-        'name': 'comment.block.string.quoted.double.menhir'
-        'patterns': [
-          {
-            'match': '\\\\(x[a-fA-F0-9][a-fA-F0-9]|[0-2]\\d\\d|[bnrt\'"\\\\])'
-            'name': 'comment.block.string.constant.character.escape.menhir'
-          }
-        ]
-      }
-    ]
-  'declaration-matches':
-    'patterns': [
-      {
-        'begin': '%token'
+        'begin': '(%parameter)\\s*(<)'
         'beginCaptures':
-          '0':
-            'name': 'keyword.other.directive.token.menhir'
-        'end': '^\\s*($|(^\\s*(?=%)))'
-        'name': 'meta.token.declaration.menhir'
-        'patterns': [
-          { 'include': '#symbol-types' }
-          {
-            'match': '[A-Z][A-Za-z0-9_]*'
-            'name': 'entity.name.type.token.menhir'
-          }
-          { 'include': '#comments' }
-        ]
+          '1': {'name': 'keyword.other.directive.menhir'}
+        'end': '(>)'
+        'patterns': [{'include': 'source.ocaml'}]
       }
       {
-        'begin': '%left|%right|%nonassoc'
+        'begin': '(%start|%type)\\s*(<)'
         'beginCaptures':
-          '0':
-            'name': 'keyword.other.directive.token.associativity.menhir'
-        'end': '(^\\s*$)|(^\\s*(?=%))'
-        'name': 'meta.token.associativity.menhir'
-        'patterns': [
-          {
-            'match': '[A-Z][A-Za-z0-9_]*'
-            'name': 'entity.name.type.token.menhir'
-          }
-          {
-            'match': '[a-z][A-Za-z0-9_]*'
-            'name': 'entity.name.function.non-terminal.reference.menhir'
-          }
-          { 'include': '#comments' }
-        ]
+          '1': {'name': 'keyword.other.directive.menhir'}
+        'end': '(>)([^\\r\\n]+)'
+        'endCaptures':
+          '2': {'patterns': [{'include': '#lident'}]}
+        'patterns': [{'include': 'source.ocaml#typedefs'}]
       }
       {
-        'begin': '%start'
+        'begin': '(%token)\\s*(<)'
         'beginCaptures':
-          '0':
-            'name': 'keyword.other.directive.start-symbol.menhir'
-        'end': '^\\s*($|(^\\s*(?=%)))'
-        'name': 'meta.start-symbol.menhir'
-        'patterns': [
-          { 'include': '#symbol-types'}
-          {
-            'match': '[a-z][A-Za-z0-9_]*'
-            'name': 'entity.name.function.non-terminal.reference.menhir'
-          }
-          { 'include': '#comments' }
-        ]
+          '1': {'name': 'keyword.other.directive.menhir'}
+        'end': '(>)([^\\r\\n]+)'
+        'endCaptures':
+          '2': {'patterns': [{'include': '#uident'}]}
+        'patterns': [{'include': 'source.ocaml#typedefs'}]
       }
       {
-        'begin': '%type'
-        'beginCaptures':
-          '0':
-            'name': 'keyword.other.directive.type.menhir'
-        'end': '$\\s*(?!%)'
-        'name': 'meta.symbol-type.menhir'
-        'patterns': [
-          { 'include': '#symbol-types' }
-          {
-            'match': '[A-Z][A-Za-z0-9_]*'
-            'name': 'entity.name.type.token.reference.menhir'
-          }
-          {
-            'match': '[a-z][A-Za-z0-9_]*'
-            'name': 'entity.name.function.non-terminal.reference.menhir'
-          }
-          { 'include': '#comments' }
-        ]
-      }
-    ]
-  'precs':
-    'patterns': [
-      {
+        'match': '(%token|%nonassoc|%left|%right)([^<>\\r\\n]+)'
         'captures':
-          '1':
-            'name': 'keyword.other.decorator.precedence.menhir'
-          '2':
-            'name': 'keyword.other.precedence.menhir'
-          '4':
-            'name': 'entity.name.function.non-terminal.reference.menhir'
-          '5':
-            'name': 'entity.name.type.token.reference.menhir'
-        'match': '(%)(prec)\\s+(([a-z][a-zA-Z0-9_]*)|(([A-Z][a-zA-Z0-9_]*)))'
-        'name': 'meta.precedence.declaration'
+          '1': {'name': 'keyword.other.directive.menhir'}
+          '2': {'patterns': [{'include': '#uident'}]}
+      }
+      {
+        'begin': '%%'
+        'beginCaptures':
+          '0': {'name': 'keyword.other.rules.begin.menhir'}
+        'end': '%%'
+        'endCaptures':
+          '0': {'name': 'keyword.other.rules.end.menhir'}
+        'patterns': [{'include': '#rule'}]
       }
     ]
-  'variables':
+  'rule':
     'patterns': [
       {
-        'match': '([a-z][A-Za-z0-9_]*)\\s*='
+        'match': '\\(([^)]+)\\)(?=\\s*:)'
         'captures':
-          '1':
-            'name': 'variable.parameter.menhir'
-        'name': 'meta.assignment.menhir'
-        'patterns': [{ 'include': '#references' }]
-      }
-    ]
-  'references':
-    'patterns': [
-      {
-        'match': '[a-z][a-zA-Z0-9_]*'
-        'name': 'entity.name.function.non-terminal.reference.menhir'
+          '1': {'patterns': [{'include': '#ident'}]}
       }
       {
-        'match': '[A-Z][a-zA-Z0-9_]*'
-        'name': 'entity.name.type.token.reference.menhir'
+        'match': '%public|%inline'
+        'name': 'keyword.other.modifier.menhir'
       }
+      {'include': '#action'}
+      {'include': '#uident'}
+      {'include': '#lident'}
     ]
-  'rule-patterns':
-    'patterns': [
-      {
-        'begin': '((?<!\\|)(\\|)(?!:))'
-        'end': '(?<=})\s'
-        'name': 'meta.rule-pattern.menhir'
-        'patterns': [
-          { 'include': '#precs' }
-          { 'include': '#semantic-actions' }
-          { 'include': '#variables' }
-          { 'include': '#references' }
-          { 'include': '#comments' }
-        ]
-      }
-    ]
-  'rules':
-    'patterns': [
-      {
-        'begin': '(?:(%public|%inline)\\s*)?([a-z][a-zA-Z0-9_]*)(?:\\s*\\(.*?\\))?(?=\\s*(:|\\|))'
-        'beginCaptures':
-          '1':
-            'name': 'keyword.other.menhir'
-          '2':
-            'name': 'entity.name.function.non-terminal.rule.begin.menhir'
-        'end': '(?=[^{}]+:)'
-        'endCaptures':
-          '0':
-            'name': 'entity.name.function.non-terminal.rule.end.menhir'
-        'name': 'meta.non-terminal.rule.menhir'
-        'patterns': [{ 'include': '#rule-patterns' }]
-      }
-    ]
-  'semantic-actions':
-    'patterns': [
-      {
-        'begin': '[^\\\']({)'
-        'beginCaptures':
-          '1':
-            'name': 'punctuation.definition.action.semantic.begin.menhir'
-        'end': '(})'
-        'endCaptures':
-          '1':
-            'name': 'punctuation.definition.action.semantic.end.menhir'
-        'name': 'meta.action.semantic.menhir'
-        'patterns': [{ 'include': 'source.ocaml' }]
-      }
-    ]
-  'symbol-types':
-    'patterns': [
-      {
-        'begin': '<'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.definition.type-declaration.begin.menhir'
-        'end': '>'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.definition.type-declaration.end.menhir'
-        'name': 'meta.token.type-declaration.menhir'
-        'patterns': [{ 'include': 'source.ocaml' }]
-      }
-    ]
-'scopeName': 'source.menhir'
+  'action':
+    'begin': '(?<![\\\'])({)'
+    'end': '(})(?!\\S+)'
+    'patterns': [{'include': 'source.ocaml'}]
+  'uident':
+    'match': '[A-Z][a-zA-Z0-9_]*'
+    'name': 'entity.name.tag.token.ocaml'
+  'lident':
+    'match': '[a-z][a-zA-Z0-9_]*'
+    'name': 'entity.name.function.rule.menhir'
+  'ident':
+    'match': '[a-zA-Z][a-zA-Z0-9_]*'
+    'name': 'variable.parameter.rule.menhir'

--- a/grammars/ocaml.cson
+++ b/grammars/ocaml.cson
@@ -808,13 +808,13 @@
   'module-signature':
     'patterns': [
       {
-        'begin': '(val)\\s+([a-z_][a-zA-Z0-9_\']*)\\s*(:)'
+        'begin': '(val)\\s+(([a-z_][a-zA-Z0-9_\']*)|(\\(\\s*[=<>@^&+\\-*/$%|][|!$%&*+./:<=>?@^~-]*\\s*\\)))\\s*(:)'
         'beginCaptures':
           '1':
             'name': 'keyword.other.ocaml'
           '2':
             'name': 'entity.name.type.value-signature.ocaml'
-          '3':
+          '5':
             'name': 'punctuation.separator.type-constraint.ocaml'
         'end': '(?=\\b(type|val|external|class|module|end)\\b)|^\\s*$'
         'name': 'meta.module.signature.val.ocaml'

--- a/grammars/ocaml.cson
+++ b/grammars/ocaml.cson
@@ -620,7 +620,7 @@
     'name': 'keyword.control.ocaml'
   }
   {
-    'match': '\\b(as|assert|class|constraint|exception|functor|in|include|inherit|initializer|lazy|let|mod|module|mutable|new|object|open|private|rec|sig|struct|type|virtual)\\b'
+    'match': '\\b(as|assert|class|constraint|exception|functor|in|include|inherit|initializer|lazy|let|mod|module|mutable|new|object|open|private|rec|raise|sig|struct|type|virtual)\\b'
     'name': 'keyword.other.ocaml'
   }
   {

--- a/grammars/ocaml.cson
+++ b/grammars/ocaml.cson
@@ -507,11 +507,11 @@
     'name': 'entity.name.type.variant.ocaml'
   }
   {
-    'match': '!=|:=|>|<'
-    'name': 'keyword.operator.symbol.ocaml'
+    'match': '(!=|:=|>|<)(?![|!$%&*+./:<=>?@^~-])'
+    'name': 'keyword.operator.infix.symbol.ocaml'
   }
   {
-    'match': '[*+/-]\\.'
+    'match': '[*+/-]\\.(?![|!$%&*+./:<=>?@^~-])'
     'name': 'keyword.operator.infix.floating-point.ocaml'
   }
   {
@@ -531,12 +531,12 @@
     'name': 'punctuation.separator.ocaml'
   }
   {
-    'match': '->'
+    'match': '->(?![|!$%&*+./:<=>?@^~-])'
     'name': 'punctuation.separator.function-return.ocaml'
   }
   {
     'match': '[=<>@^&+\\-*/$%|][|!$%&*+./:<=>?@^~-]*'
-    'name': 'keyword.operator.infix.ocaml'
+    'name': 'entity.name.function.infix.ocaml'
   }
   {
     'match': '\\bnot\\b|!|[!\\?~][!$%&*+./:<=>?@^~-]+'

--- a/grammars/ocaml.cson
+++ b/grammars/ocaml.cson
@@ -625,11 +625,11 @@
         'name': 'support.function.pervasives.comparisons.ocaml'
       }
       {
-        'match': '\\b(not|or)\\b'
+        'match': '\\bnot\\b'
         'name': 'support.function.pervasives.boolean-operatons.ocaml'
       }
       {
-        'match': '(?<![|!$%&*+./:<=>?@^~-])(&&|&|\\|\\|)(?![|!$%&*+./:<=>?@^~-])'
+        'match': '(?<![|!$%&*+./:<=>?@^~-])(&&|\\|\\|)(?![|!$%&*+./:<=>?@^~-])'
         'name': 'support.function.pervasives.boolean-operatons.ocaml'
       }
       {
@@ -643,6 +643,14 @@
       {
         'match': '(?<![|!$%&*+./:<=>?@^~-])\\^(?![|!$%&*+./:<=>?@^~-])'
         'name': 'support.function.pervasives.string-operation.ocaml'
+      }
+      {
+        'match': '(?<![|!$%&*+./:<=>?@^~-])&(?![|!$%&*+./:<=>?@^~-])'
+        'name': 'invalid.deprecated.pervasives.boolean-operatons.ocaml'
+      }
+      {
+        'match': '\\bor\\b'
+        'name': 'invalid.deprecated.pervasives.boolean-operatons.ocaml'
       }
     ]
 

--- a/grammars/ocaml.cson
+++ b/grammars/ocaml.cson
@@ -640,6 +640,10 @@
         'match': '(?<![|!$%&*+./:<=>?@^~-])(\\|>|@@)(?![|!$%&*+./:<=>?@^~-])'
         'name': 'support.function.pervasives.composition.ocaml'
       }
+      {
+        'match': '(?<![|!$%&*+./:<=>?@^~-])\\^(?![|!$%&*+./:<=>?@^~-])'
+        'name': 'support.function.pervasives.string-operation.ocaml'
+      }
     ]
 
 

--- a/grammars/ocaml.cson
+++ b/grammars/ocaml.cson
@@ -21,6 +21,38 @@
     'name': 'meta.module.binding'
   }
   {
+    'comment': 'Scoped declaration'
+    'begin': '(?=\\blet\\b)'
+    'end': '(?<=in)'
+    'patterns': [
+      {
+        'comment': 'Matches everything between the `let` and the `=`'
+        'begin': '\\blet\\b'
+        'beginCaptures':
+          '0':
+            'name': 'keyword.other.let_binding.ocaml'
+        'end': '(?==)'
+        'patterns': [
+          {'include': '$self'}
+        ]
+      }
+      {
+        'comment': 'Matches everything between the `=` and the `in`'
+        'begin': '='
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.separator.assignment.ocaml'
+        'end': '\\bin\\b'
+        'endCaptures':
+          '0':
+            'name': 'keyword.other.in.ocaml'
+        'patterns': [
+          {'include': '$self'}
+        ]
+      }
+    ]
+  }
+  {
     'begin': '\\b(let)\\s+(open)\\s+([A-Z][a-zA-Z0-9\'_]*)(?=(\\.[A-Z][a-zA-Z0-9_]*)*)'
     'beginCaptures':
       '1':
@@ -599,7 +631,7 @@
   }
   {
     'match': '\\b(as|assert|class|constraint|exception|functor|in|include|inherit|initializer|lazy|let|mod|module|mutable|new|object|open|private|rec|raise|sig|struct|type|virtual)\\b'
-    'name': 'keyword.other.ocaml'
+    'name': 'keyword.other.misc.ocaml'
   }
   {
     'include': '#module-signature'

--- a/grammars/ocaml.cson
+++ b/grammars/ocaml.cson
@@ -1051,13 +1051,21 @@
         ]
       }
       {
-        'captures':
+        'begin': '(\\?)([a-z][a-zA-Z0-9_]*)(\\s*:\\s*)?'
+        'beginCaptures':
           '1':
             'name': 'punctuation.definition.optional-parameter.ocaml'
           '2':
             'name': 'entity.name.tag.variable.optional.ocaml'
-        'match': '(\\?)([a-z][a-zA-Z0-9_]*)'
+          '3':
+            'name': 'punctuation.separator.variable.ocaml'
+        'end': '(?=(->|\\s))'
         'name': 'variable.parameter.optional.ocaml'
+        'patterns': [
+          {
+            'include': '#variables'
+          }
+        ]
       }
       {
         'begin': '(\\?)(\\()([a-z_][a-zA-Z0-9\'_]*)\\s*(=)'

--- a/grammars/ocaml.cson
+++ b/grammars/ocaml.cson
@@ -70,36 +70,7 @@
     ]
   }
   {
-    'begin': '(\\()(?=fun\\s)'
-    'beginCaptures':
-      '1':
-        'name': 'punctuation.definition.function.anonymous.ocaml'
-    'end': '(\\))'
-    'endCaptures':
-      '1':
-        'name': 'punctuation.definition.function.anonymous.ocaml'
-    'name': 'meta.function.anonymous.ocaml'
-    'patterns': [
-      {
-        'include': '#anonymous-function-def'
-      }
-      {
-        'include': '$self'
-      }
-    ]
-  }
-  {
-    'begin': '(\\s)(?=fun\\s)'
-    'end': '(?=\\)|end)'
-    'name': 'meta.function.anonymous.ocaml'
-    'patterns': [
-      {
-        'include': '#anonymous-function-def'
-      }
-      {
-        'include': '$self'
-      }
-    ]
+    'include': '#anonymous-function-def'
   }
   {
     'begin': '^\\s*(?=type\\s)'
@@ -643,14 +614,14 @@
   'anonymous-function-def':
     'patterns': [
       {
-        'begin': '(?<=(\\(|\\s))(fun)\\s'
+        'begin': '\\bfun\\b'
         'beginCaptures':
-          '2':
+          '0':
             'name': 'keyword.other.function-definition.ocaml'
-        'end': '(->)'
+        'end': '->'
         'endCaptures':
-          '1':
-            'name': 'punctuation.separator.function-definition.ocaml'
+          '0':
+            'name': 'keyword.other.anonymous-function-arrow.ocaml'
         'name': 'meta.function.anonymous.definition.ocaml'
         'patterns': [
           {

--- a/grammars/ocaml.cson
+++ b/grammars/ocaml.cson
@@ -507,8 +507,12 @@
     'name': 'entity.name.type.variant.ocaml'
   }
   {
-    'match': '(!=|:=|>|<)(?![|!$%&*+./:<=>?@^~-])'
+    'match': '(!=|:=|>|<|=|<>)(?![|!$%&*+./:<=>?@^~-])'
     'name': 'keyword.operator.infix.symbol.ocaml'
+  }
+  {
+    'match': '[*+/-](?![|!$%&*+./:<=>?@^~-])'
+    'name': 'keyword.operator.infix.integer.ocaml'
   }
   {
     'match': '[*+/-]\\.(?![|!$%&*+./:<=>?@^~-])'

--- a/grammars/ocaml.cson
+++ b/grammars/ocaml.cson
@@ -1023,7 +1023,11 @@
     'patterns': [
       {
         'match': '\\(\\)'
-        'name': 'variable.parameter.unit.ocaml'
+        'name': 'constant.language.unit.ocaml'
+      }
+      {
+        'match': '\\b_\\b'
+        'name': 'constant.language.universal-match.ocaml'
       }
       {
         'include': '#constants'

--- a/grammars/ocaml.cson
+++ b/grammars/ocaml.cson
@@ -126,7 +126,7 @@
     ]
   }
   {
-    'begin': '\\b(with|function)(?=(\\s*$|.*->))\\b|((?<!\\S)(\\|)(?=(\\w|\\s).*->))'
+    'begin': '(?:\\b(with|function)(?=(\\s*$|.*->))\\b|((?<!\\S)(?:\\|)(?=(?:\\w|\\s).*->)))(?:\\s*(exception)\\b)?'
     'beginCaptures':
       '1':
         'name': 'keyword.control.match-definition.ocaml'
@@ -134,6 +134,8 @@
         'name': 'keyword.other.function-definition.ocaml'
       '3':
         'name': 'keyword.control.match-definition.ocaml'
+      '4':
+        'name': 'keyword.control.match-exception.ocaml'
     'end': '(?:(->)|\\b(when)\\b|(?:^|\\s)(?=\\|))'
     'endCaptures':
       '1':

--- a/grammars/ocaml.cson
+++ b/grammars/ocaml.cson
@@ -97,7 +97,7 @@
     ]
   }
   {
-    'begin': '(?:\\b(with|function)(?=(\\s*$|.*->))\\b|((?<!\\S)(?:\\|)(?=(?:\\w|\\s).*->)))(?:\\s*(exception)\\b)?'
+    'begin': '(?:\\b(with|function)(?=(\\s*$|.*->))\\b|((?<!\\S)(?:\\|)(?=(?:\\w|\\s).*)))(?:\\s*(exception)\\b)?'
     'beginCaptures':
       '1':
         'name': 'keyword.control.match-definition.ocaml'

--- a/grammars/ocaml.cson
+++ b/grammars/ocaml.cson
@@ -70,7 +70,7 @@
     ]
   }
   {
-    'begin': '(\\(|\\s)(?=fun\\s)'
+    'begin': '(\\()(?=fun\\s)'
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.function.anonymous.ocaml'
@@ -81,20 +81,20 @@
     'name': 'meta.function.anonymous.ocaml'
     'patterns': [
       {
-        'begin': '(?<=(\\(|\\s))(fun)\\s'
-        'beginCaptures':
-          '2':
-            'name': 'keyword.other.function-definition.ocaml'
-        'end': '(->)'
-        'endCaptures':
-          '1':
-            'name': 'punctuation.separator.function-definition.ocaml'
-        'name': 'meta.function.anonymous.definition.ocaml'
-        'patterns': [
-          {
-            'include': '#variables'
-          }
-        ]
+        'include': '#anonymous-function-def'
+      }
+      {
+        'include': '$self'
+      }
+    ]
+  }
+  {
+    'begin': '(\\s)(?=fun\\s)'
+    'end': '(?=\\))'
+    'name': 'meta.function.anonymous.ocaml'
+    'patterns': [
+      {
+        'include': '#anonymous-function-def'
       }
       {
         'include': '$self'
@@ -632,6 +632,25 @@
   }
 ]
 'repository':
+  'anonymous-function-def':
+    'patterns': [
+      {
+        'begin': '(?<=(\\(|\\s))(fun)\\s'
+        'beginCaptures':
+          '2':
+            'name': 'keyword.other.function-definition.ocaml'
+        'end': '(->)'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.separator.function-definition.ocaml'
+        'name': 'meta.function.anonymous.definition.ocaml'
+        'patterns': [
+          {
+            'include': '#variables'
+          }
+        ]
+      }
+    ]
   'arrays':
     'patterns': [
       {

--- a/grammars/ocaml.cson
+++ b/grammars/ocaml.cson
@@ -478,10 +478,6 @@
     'name': 'entity.name.type.variant.ocaml'
   }
   {
-    'match': '(!=|:=|>|<|=|<>)(?![|!$%&*+./:<=>?@^~-])'
-    'name': 'keyword.operator.infix.symbol.ocaml'
-  }
-  {
     'match': '[*+/-](?![|!$%&*+./:<=>?@^~-])'
     'name': 'keyword.operator.infix.integer.ocaml'
   }
@@ -508,6 +504,9 @@
   {
     'match': '->(?![|!$%&*+./:<=>?@^~-])'
     'name': 'punctuation.separator.function-return.ocaml'
+  }
+  {
+    'include': '#pervasives'
   }
   {
     'match': '[=<>@^&+\\-*/$%|][|!$%&*+./:<=>?@^~-]*'
@@ -611,6 +610,39 @@
   }
 ]
 'repository':
+  'pervasives':
+    'patterns': [
+      {
+        'match': '\\b(raise|raise_notrace|invalid_arg|failwith)\\b'
+        'name': 'support.function.pervasives.exceptions.ocaml'
+      }
+      {
+        'match': '\\b(compare|min|max)\\b'
+        'name': 'support.function.pervasives.comparisons.ocaml'
+      }
+      {
+        'match': '(?<![|!$%&*+./:<=>?@^~-])(=|<>|<|>|<=|>=|==|!=)(?![|!$%&*+./:<=>?@^~-])'
+        'name': 'support.function.pervasives.comparisons.ocaml'
+      }
+      {
+        'match': '\\b(not|or)\\b'
+        'name': 'support.function.pervasives.boolean-operatons.ocaml'
+      }
+      {
+        'match': '(?<![|!$%&*+./:<=>?@^~-])(&&|&|\\|\\|)(?![|!$%&*+./:<=>?@^~-])'
+        'name': 'support.function.pervasives.boolean-operatons.ocaml'
+      }
+      {
+        'match': '\\b(__LOC__|__FILE__|__LINE__|__MODULE__|__POS__|__LOC_OF__|__LINE_OF__|__POS_OF__)\\b'
+        'name': 'support.function.pervasives.debugging.ocaml'
+      }
+      {
+        'match': '(?<![|!$%&*+./:<=>?@^~-])(\\|>|@@)(?![|!$%&*+./:<=>?@^~-])'
+        'name': 'support.function.pervasives.composition.ocaml'
+      }
+    ]
+
+
   'anonymous-function-def':
     'patterns': [
       {

--- a/grammars/ocaml.cson
+++ b/grammars/ocaml.cson
@@ -90,7 +90,7 @@
   }
   {
     'begin': '(\\s)(?=fun\\s)'
-    'end': '(?=\\))'
+    'end': '(?=\\)|end)'
     'name': 'meta.function.anonymous.ocaml'
     'patterns': [
       {

--- a/grammars/ocaml.cson
+++ b/grammars/ocaml.cson
@@ -700,6 +700,10 @@
           {
             'include': '#comments'
           }
+          {
+            'include': '#comment_strings'
+            'name': 'comment.block.ocaml'
+          }
         ]
       }
     ]
@@ -984,6 +988,27 @@
           {
             'match': '\\\\(?!(x[a-fA-F0-9][a-fA-F0-9]|[0-2]\\d\\d|[bnrt\'"\\\\]|[\\|\\(\\)1-9$^.*+?\\[\\]]|$[ \\t]*))(?:.)'
             'name': 'invalid.illegal.character.string.escape'
+          }
+        ]
+      }
+    ]
+  'comment_strings':
+    'patterns': [
+      {
+        'begin': '(?=[^\\\\])(")'
+        'end': '(")'
+        'patterns': [
+          {
+            'match': '\\\\$[ \\t]*'
+          }
+          {
+            'match': '\\\\(x[a-fA-F0-9][a-fA-F0-9]|[0-2]\\d\\d|[bnrt\'"\\\\])'
+          }
+          {
+            'match': '\\\\[\\|\\(\\)1-9$^.*+?\\[\\]]'
+          }
+          {
+            'match': '\\\\(?!(x[a-fA-F0-9][a-fA-F0-9]|[0-2]\\d\\d|[bnrt\'"\\\\]|[\\|\\(\\)1-9$^.*+?\\[\\]]|$[ \\t]*))(?:.)'
           }
         ]
       }

--- a/grammars/ocaml.cson
+++ b/grammars/ocaml.cson
@@ -410,7 +410,9 @@
         'name': 'keyword.other.ocaml'
       '2':
         'name': 'entity.name.type.exception.ocaml'
-    'match': '\\b(exception)\\s+([A-Z][a-zA-Z0-9\'_]*)\\b'
+      '3':
+        'name': 'keyword.other.ocaml'
+    'match': '\\b(exception)\\s+([A-Z][a-zA-Z0-9\'_]*)(?:\\s+(of))?\\b'
     'name': 'meta.exception.ocaml'
   }
   {

--- a/grammars/ocamllex.cson
+++ b/grammars/ocamllex.cson
@@ -37,7 +37,7 @@
     ]
   }
   {
-    'begin': '(rule|and)\\s+([a-z][a-zA-Z0-9_]*)\\s+(=)\\s+(parse)(?=\\s*$)|((?<!\\|)(\\|)(?!\\|))'
+    'begin': '(rule|and)\\s+([a-z][a-zA-Z0-9_]*)(?:\\s+(?:[a-z][a-zA-Z0-9_]*))*\\s+(=)\\s+(parse)(?=\\s*$)|((?<!\\|)(\\|)(?!\\|))'
     'beginCaptures':
       '1':
         'name': 'keyword.other.ocamllex'
@@ -169,10 +169,6 @@
         ]
       }
       {
-        'match': '[a-z][a-zA-Z0-9\'_]'
-        'name': 'entity.name.type.pattern.reference.stupid-goddamn-hack.ocamllex'
-      }
-      {
         'match': '\\bas\\b'
         'name': 'keyword.other.pattern.ocamllex'
       }
@@ -183,6 +179,10 @@
       {
         'match': '_'
         'name': 'constant.language.universal-match.ocamllex'
+      }
+      {
+        'match': '[a-z][a-zA-Z0-9\'_]'
+        'name': 'entity.name.type.pattern.reference.stupid-goddamn-hack.ocamllex'
       }
       {
         'begin': '(\\[)(\\^?)'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/andreasdahl/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/hackwaly/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/hackwaly/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/hackwaly/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/hackwaly/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/andreasdahl/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/andreasdahl/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/hackwaly/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/andreasdahl/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/hackwaly/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/andreasdahl/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.4.0",
   "private": true,
   "description": "Syntax support for the OCaml language",
-  "repository": "https://github.com/hackwaly/language-ocaml-fix",
+  "repository": "https://github.com/andreasdahl/language-ocaml-fix",
   "license": "MIT",
   "engines": {
     "atom": ">0.50.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/andreasdahl/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/hackwaly/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/andreasdahl/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.3.6",
+  "version": "1.4.0",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/hackwaly/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/andreasdahl/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/hackwaly/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/andreasdahl/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -8,5 +8,8 @@
   "engines": {
     "atom": ">0.50.0"
   },
-  "dependencies'": {}
+  "dependencies": {},
+  "devDependencies": {
+    "atom-grammar-test": "^0.6.3"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/hackwaly/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/andreasdahl/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/andreasdahl/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/hackwaly/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "language-ocaml",
+  "name": "language-ocaml-fix",
   "version": "1.1.3",
   "private": true,
   "description": "Syntax support for the OCaml language",
-  "repository": "https://github.com/toroidal-code/language-ocaml",
+  "repository": "https://github.com/hackwaly/language-ocaml-fix",
   "license": "MIT",
   "engines": {
     "atom": ">0.50.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/andreasdahl/language-ocaml-fix",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/toroidal-code/language-ocaml",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-ocaml-fix",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "private": true,
   "description": "Syntax support for the OCaml language",
   "repository": "https://github.com/hackwaly/language-ocaml-fix",

--- a/settings/language-ocaml.cson
+++ b/settings/language-ocaml.cson
@@ -2,3 +2,8 @@
   'editor':
     'commentStart': '(* '
     'commentEnd': ' *)'
+
+'.source.ocamllex':
+  'editor':
+    'commentStart': '(* '
+    'commentEnd': ' *)'

--- a/snippets/language-ocaml.cson
+++ b/snippets/language-ocaml.cson
@@ -33,6 +33,9 @@
   'let':
     'prefix': 'let'
     'body': 'let ${1:var(s)} = ${0:expr}'
+  'let_':
+    'prefix': 'let_'
+    'body': 'let (_:int) = ${0:expr}'
   'match pattern':
     'prefix': '|'
     'body': '| ${1:pattern} -> $0'

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -1,0 +1,11 @@
+path = require 'path'
+grammarTest = require 'atom-grammar-test'
+
+describe 'OCaml grammar', ->
+
+  beforeEach ->
+    # Ensure you're language package is loaded
+    waitsForPromise ->
+      atom.packages.activatePackage 'language-ocaml-fix',
+
+  grammarTest(path.join(__dirname, 'ocaml.spec'))

--- a/spec/ocaml.spec
+++ b/spec/ocaml.spec
@@ -50,3 +50,17 @@ begin fun x -> y end
 //  ^ keyword.operator.infix.integer.ocaml
    a|>b
 //  ^^ entity.name.function.infix.ocaml
+val test: a -> b
+// <- keyword.other.ocaml
+//  ^^^^ entity.name.type.value-signature.ocaml
+//      ^ punctuation.separator.type-constraint.ocaml
+//        ^ storage.type.ocaml
+//          ^^ punctuation.separator.function-return.ocaml
+//             ^ storage.type.ocaml
+val ( >> ): a -> b
+// <- keyword.other.ocaml
+//  ^^^^^^ entity.name.type.value-signature.ocaml
+//        ^ punctuation.separator.type-constraint.ocaml
+//          ^ storage.type.ocaml
+//            ^^ punctuation.separator.function-return.ocaml
+//               ^ storage.type.ocaml

--- a/spec/ocaml.spec
+++ b/spec/ocaml.spec
@@ -1,12 +1,20 @@
 // SYNTAX TEST "source.ocaml"
 (* test *)
 // ^ comment.block.ocaml
+fun x -> y
+// <- keyword.other.function-definition.ocaml
+// <- meta.function.anonymous.definition.ocaml
+//^^^^^^ meta.function.anonymous.definition.ocaml
+//  ^ variable.parameter.ocaml
+//    ^^ keyword.other.anonymous-function-arrow.ocaml
+//      ^^ !meta.function.anonymous.definition.ocaml
 begin fun x -> y end
 // <- keyword.control.begin-end.ocaml
-//    ^^^^^^^^^^ meta.function.anonymous.ocaml
-//               ^^^ !meta.function.anonymous.ocaml
+//    ^^^^^^^^ meta.function.anonymous.definition.ocaml
+//    ^^^ meta.function.anonymous.definition.ocaml
 //        ^ variable.parameter.ocaml
-//          ^^ punctuation.separator.function-definition.ocaml
+//          ^^ keyword.other.anonymous-function-arrow.ocaml
+//             ^^^^^ !meta.function.anonymous.definition.ocaml
 //               ^^^ keyword.control.begin-end.ocaml
    a>>=b
 //  ^^^ entity.name.function.infix.ocaml

--- a/spec/ocaml.spec
+++ b/spec/ocaml.spec
@@ -64,3 +64,15 @@ val ( >> ): a -> b
 //          ^ storage.type.ocaml
 //            ^^ punctuation.separator.function-return.ocaml
 //               ^ storage.type.ocaml
+fun () -> a
+// <- keyword.other.function-definition.ocaml
+// <- meta.function.anonymous.definition.ocaml
+//^^^^^^^ meta.function.anonymous.definition.ocaml
+//  ^^ constant.language.unit.ocaml
+//     ^^ keyword.other.anonymous-function-arrow.ocaml
+fun _ -> a
+// <- keyword.other.function-definition.ocaml
+// <- meta.function.anonymous.definition.ocaml
+//^^^^^^ meta.function.anonymous.definition.ocaml
+//  ^ constant.language.universal-match.ocaml
+//    ^^ keyword.other.anonymous-function-arrow.ocaml

--- a/spec/ocaml.spec
+++ b/spec/ocaml.spec
@@ -82,9 +82,9 @@ begin
   raise a
 //^^^^^ support.function
   raise_notrace a
-//^^^^^ support.function
+//^^^^^^^^^^^^^ support.function
   invalid_arg a
-//^^^^^ support.function
+//^^^^^^^^^^^ support.function
   failwith a
 //^^^^^^^^ support.function
   compare a b
@@ -112,11 +112,11 @@ begin
   not a
 //^^^ support.function
 a or b
-//^^ support.function
+//^^ invalid.deprecated
  a&&b
 //^^ support.function
   a&b
-// ^ support.function
+// ^ invalid.deprecated
  a||b
 //^^ support.function
  a|>b

--- a/spec/ocaml.spec
+++ b/spec/ocaml.spec
@@ -8,3 +8,15 @@ begin fun x -> y end
 //        ^ variable.parameter.ocaml
 //          ^^ punctuation.separator.function-definition.ocaml
 //               ^^^ keyword.control.begin-end.ocaml
+   a>>=b
+//  ^^^ entity.name.function.infix.ocaml
+   a!=b
+//  ^^ keyword.operator.infix.symbol.ocaml
+   a>b
+//  ^ keyword.operator.infix.symbol.ocaml
+   a<b
+//  ^ keyword.operator.infix.symbol.ocaml
+   a->b
+//  ^^ punctuation.separator.function-return.ocaml
+   a->>b
+//  ^^^ entity.name.function.infix.ocaml

--- a/spec/ocaml.spec
+++ b/spec/ocaml.spec
@@ -123,6 +123,8 @@ a or b
 //^^ support.function
  a@@b
 //^^ support.function
+ a^b
+//^ support.function
 end
 
   (*  *)

--- a/spec/ocaml.spec
+++ b/spec/ocaml.spec
@@ -1,6 +1,6 @@
 // SYNTAX TEST "source.ocaml"
 (* test *)
-// ^ comment.block.ocaml
+// ^^^^ comment.block.ocaml
 fun x -> y
 // <- keyword.other.function-definition.ocaml
 // <- meta.function.anonymous.definition.ocaml
@@ -124,3 +124,10 @@ a or b
  a@@b
 //^^ support.function
 end
+
+  (*  *)
+//^^^^^^ comment.block.ocaml
+  (* "test" *)
+//^^^^^^^^^^^^ comment.block.ocaml
+  (* "*)" *)
+//^^^^^^^^^^ comment.block.ocaml

--- a/spec/ocaml.spec
+++ b/spec/ocaml.spec
@@ -18,16 +18,6 @@ begin fun x -> y end
 //               ^^^ keyword.control.begin-end.ocaml
    a>>=b
 //  ^^^ entity.name.function.infix.ocaml
-   a!=b
-//  ^^ keyword.operator.infix.symbol.ocaml
-   a=b
-//  ^ keyword.operator.infix.symbol.ocaml
-   a<>b
-//  ^^ keyword.operator.infix.symbol.ocaml
-   a>b
-//  ^ keyword.operator.infix.symbol.ocaml
-   a<b
-//  ^ keyword.operator.infix.symbol.ocaml
    a->b
 //  ^^ punctuation.separator.function-return.ocaml
    a->>b
@@ -48,8 +38,6 @@ begin fun x -> y end
 //  ^ keyword.operator.infix.integer.ocaml
    a*b
 //  ^ keyword.operator.infix.integer.ocaml
-   a|>b
-//  ^^ entity.name.function.infix.ocaml
 val test: a -> b
 // <- keyword.other.ocaml
 //  ^^^^ entity.name.type.value-signature.ocaml
@@ -89,4 +77,50 @@ begin match a with
   | b -> b
 //^ keyword.control.match-definition.ocaml
 //    ^^ punctuation.separator.match-definition.ocaml
+end
+begin
+  raise a
+//^^^^^ support.function
+  raise_notrace a
+//^^^^^ support.function
+  invalid_arg a
+//^^^^^ support.function
+  failwith a
+//^^^^^^^^ support.function
+  compare a b
+//^^^^^^^ support.function
+  min a b
+//^^^ support.function
+  max a b
+//^^^ support.function
+ a=b
+//^ support.function
+ a<>b
+//^^ support.function
+ a<b
+//^ support.function
+ a>b
+//^ support.function
+ a<=b
+//^^ support.function
+ a>=b
+//^^ support.function
+ a==b
+//^^ support.function
+ a!=b
+//^^ support.function
+  not a
+//^^^ support.function
+a or b
+//^^ support.function
+ a&&b
+//^^ support.function
+  a&b
+// ^ support.function
+ a||b
+//^^ support.function
+ a|>b
+//^^ support.function
+ a@@b
+//^^ support.function
 end

--- a/spec/ocaml.spec
+++ b/spec/ocaml.spec
@@ -12,6 +12,10 @@ begin fun x -> y end
 //  ^^^ entity.name.function.infix.ocaml
    a!=b
 //  ^^ keyword.operator.infix.symbol.ocaml
+   a=b
+//  ^ keyword.operator.infix.symbol.ocaml
+   a<>b
+//  ^^ keyword.operator.infix.symbol.ocaml
    a>b
 //  ^ keyword.operator.infix.symbol.ocaml
    a<b
@@ -20,3 +24,21 @@ begin fun x -> y end
 //  ^^ punctuation.separator.function-return.ocaml
    a->>b
 //  ^^^ entity.name.function.infix.ocaml
+   a+.b
+//  ^^ keyword.operator.infix.floating-point.ocaml
+   a-.b
+//  ^^ keyword.operator.infix.floating-point.ocaml
+   a/.b
+//  ^^ keyword.operator.infix.floating-point.ocaml
+   a*.b
+//  ^^ keyword.operator.infix.floating-point.ocaml
+   a+b
+//  ^ keyword.operator.infix.integer.ocaml
+   a-b
+//  ^ keyword.operator.infix.integer.ocaml
+   a/b
+//  ^ keyword.operator.infix.integer.ocaml
+   a*b
+//  ^ keyword.operator.infix.integer.ocaml
+   a|>b
+//  ^^ entity.name.function.infix.ocaml

--- a/spec/ocaml.spec
+++ b/spec/ocaml.spec
@@ -76,3 +76,17 @@ fun _ -> a
 //^^^^^^ meta.function.anonymous.definition.ocaml
 //  ^ constant.language.universal-match.ocaml
 //    ^^ keyword.other.anonymous-function-arrow.ocaml
+begin function
+  | a
+//^ keyword.control.match-definition.ocaml
+  | a -> a
+//^ keyword.control.match-definition.ocaml
+//    ^^ punctuation.separator.match-definition.ocaml
+end
+begin match a with
+  | b
+//^ keyword.control.match-definition.ocaml
+  | b -> b
+//^ keyword.control.match-definition.ocaml
+//    ^^ punctuation.separator.match-definition.ocaml
+end

--- a/spec/ocaml.spec
+++ b/spec/ocaml.spec
@@ -133,3 +133,8 @@ end
 //^^^^^^^^^^^^ comment.block.ocaml
   (* "*)" *)
 //^^^^^^^^^^ comment.block.ocaml
+
+let a = b in c
+//^^^ keyword.other *)
+(* //      ^ punctuation *)
+(* //          ^^ keyword.other

--- a/spec/ocaml.spec
+++ b/spec/ocaml.spec
@@ -1,0 +1,10 @@
+// SYNTAX TEST "source.ocaml"
+(* test *)
+// ^ comment.block.ocaml
+begin fun x -> y end
+// <- keyword.control.begin-end.ocaml
+//    ^^^^^^^^^^ meta.function.anonymous.ocaml
+//               ^^^ !meta.function.anonymous.ocaml
+//        ^ variable.parameter.ocaml
+//          ^^ punctuation.separator.function-definition.ocaml
+//               ^^^ keyword.control.begin-end.ocaml


### PR DESCRIPTION
Many changes have been made to the repo since @hackwaly originally forked it about a year ago. Included, but not limited to are:
* Grammar spec suite to test regression.
* Automated tests with travis
* Fixes to #13 and #21 
* Improved support for ligatures (ex. [Firacode](https://github.com/tonsky/FiraCode))
* Classify most items in [Pervasives](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Pervasives.html) as `support.*`

Known problem(s):

The `end` in the following is not highlighted
![screen shot 2017-04-06 at 10 26 13](https://cloud.githubusercontent.com/assets/1443252/24744906/f34fba14-1ab3-11e7-9dff-5ecdddb67831.png)

NB: You should remove the fork disclaimer from the readme after merge, before updating the version.

Relates to #27

PS. If this fork gets merged i will publish an update to `language-ocaml-fix` stating in the README that the changes have been merged upstream and that people should use `language-ocaml` instead.