### PR TITLE
Fix character literals

### DIFF
--- a/grammars/ocaml.cson
+++ b/grammars/ocaml.cson
@@ -809,7 +809,7 @@
         'name': 'constant.numeric.integer.ocaml'
       }
       {
-        'match': '\'(.|\\\\(x[a-fA-F0-9][a-fA-F0-9]|[0-2]\\d\\d|[bnrt\'"\\\\]))\''
+        'match': '\'([^\'\\\\]|\\\\(x[a-fA-F0-9][a-fA-F0-9]|[0-2]\\d\\d|o[0-3][0-7][0-7]|[bnrt\'"\\\\ ]))\''
         'name': 'constant.character.ocaml'
       }
     ]

--- a/grammars/ocamllex.cson
+++ b/grammars/ocamllex.cson
@@ -116,7 +116,7 @@
             'name': 'punctuation.definition.char.begin.ocamllex'
           '4':
             'name': 'punctuation.definition.char.end.ocamllex'
-        'match': '(\')([^\\\\]|\\\\(x[a-fA-F0-9][a-fA-F0-9]|[0-2]\\d\\d|[bnrt\'"\\\\]))(\')'
+        'match': '(\')([^\'\\\\]|\\\\(x[a-fA-F0-9][a-fA-F0-9]|[0-2]\\d\\d|o[0-3][0-7][0-7]|[bnrt\'"\\\\ ]))(\')'
         'name': 'constant.character.ocamllex'
       }
     ]


### PR DESCRIPTION
According to the [documentation](https://caml.inria.fr/pub/docs/manual-ocaml/lex.html#char-literal), a character literal can not be a single `'` or `\`. The octal notation and `'\ '` (space) were not supported.

With the previous regex, `'\''` was recognizes as the (incorrect) literal `'\'` followed by a single quote `'`. [Here](https://github.com/ocaml/ocaml/blob/f05f81ba200c2cad3760827e249398bc08f87acc/parsing/lexer.mll#L383) is an example.