### PR TITLE
Fix highlighting of modules after type definitions

### DIFF
--- a/grammars/ocaml.cson
+++ b/grammars/ocaml.cson
@@ -98,7 +98,7 @@
   }
   {
     'begin': '^\\s*(?=type\\s)'
-    'end': '\\b(?=let|end|val|exception|external)'
+    'end': '\\b(?=let|end|val|exception|external|module)'
     'name': 'meta.type-definition-group.ocaml'
     'patterns': [
       {
@@ -113,7 +113,7 @@
             'name': 'storage.type.ocaml'
           '3':
             'name': 'punctuation.separator.type-definition.ocaml'
-        'end': '(?=\\b(type|and|let|end|val|exception|external)\\b)|(?=^\\s*$)'
+        'end': '(?=\\b(type|and|let|end|val|exception|external|module)\\b)|(?=^\\s*$)'
         'name': 'meta.type-definition.ocaml'
         'patterns': [
           {

--- a/spec/ocaml_type_definition.spec
+++ b/spec/ocaml_type_definition.spec
@@ -34,3 +34,9 @@ type x = int
 //^^^^^^^^^^ meta.type-definition-group.ocaml
 external y : int -> unit = "y"
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^ !meta.type-definition-group.ocaml
+
+
+type x = int
+//^^^^^^^^^^ meta.type-definition-group.ocaml
+module Foo = struct end
+//^^^^^^^^^^^^^^^^^^^^^ !meta.type-definition-group.ocaml


### PR DESCRIPTION
modules were not highlighted correctly when following type definitions, since the type definition did not end properly.