### PR TITLE
Allow | to appear at end of line

### DIFF
--- a/grammars/ocaml.cson
+++ b/grammars/ocaml.cson
@@ -847,8 +847,8 @@
         'name': 'constant.language.universal-match.ocaml'
       }
       {
-        'match': '\\|(?=\\s*\\S)'
-        'name': 'punctuation.separator.match-pattern.ocaml'
+        'match': '\\|(?=$|\\s*\\S)'
+        'name': 'keyword.operator.match-pattern.ocaml'
       }
       {
         'begin': '(\\()(?=(?!=.*?->).*?\\|)'
@@ -863,7 +863,7 @@
         'patterns': [
           {
             'match': '\\|'
-            'name': 'punctuation.separator.match-option.ocaml'
+            'name': 'keyword.operator.match-option.ocaml'
           }
           {
             'include': '#matchpatterns'
@@ -1059,7 +1059,7 @@
     'patterns': [
       {
         'match': '\\|'
-        'name': 'punctuation.separator.variant-definition.ocaml'
+        'name': 'keyword.operator.variant-definition.ocaml'
       }
       {
         'include': '#comments_inner'
@@ -1112,10 +1112,6 @@
       }
       {
         'include': '$self'
-      }
-      {
-        'match': '\\|'
-        'name': 'punctuation.separator.algebraic-type.ocaml'
       }
     ]
   'function-defs':

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -12,4 +12,5 @@ describe 'OCaml grammar', ->
   grammarTest(path.join(__dirname, 'ocaml_class.spec'))
   grammarTest(path.join(__dirname, 'ocaml_external.spec'))
   grammarTest(path.join(__dirname, 'ocaml_let_binding.spec'))
+  grammarTest(path.join(__dirname, 'ocaml_match.spec'))
   grammarTest(path.join(__dirname, 'ocaml_type_definition.spec'))

--- a/spec/ocaml_match.spec
+++ b/spec/ocaml_match.spec
@@ -1,0 +1,25 @@
+// SYNTAX TEST "source.ocaml"
+match x with
+| { key = X | Y; } ->
+//^^^^^^^^^^^^^^^^ variable.parameter.record.ocaml
+//  ^^^ entity.name.tag.record.ocaml
+//      ^ punctuation.separator.record.field-assignment.ocaml
+//        ^^^^^ meta.recordfield.match.ocaml
+//          ^ keyword.operator.match-pattern.ocaml
+//             ^ punctuation.separator.record.ocaml
+  let foo = ()
+//^^^ keyword.other.function-definition.ocaml
+//    ^^^ entity.name.function.ocaml
+
+match x with
+| { key = X |
+//^^^^^^^^^^^ variable.parameter.record.ocaml
+//          ^ keyword.operator.match-pattern.ocaml
+    Y; } ->
+//^^^^^^ variable.parameter.record.ocaml
+//   ^ punctuation.separator.record.ocaml
+        ^^^ !variable.parameter.record.ocaml
+  let foo = ()
+//^ !variable.parameter.record.ocaml
+//^^^ keyword.other.function-definition.ocaml
+//    ^^^ entity.name.function.ocaml


### PR DESCRIPTION
if a `|` appears at the end of the line nested within a match, it's not matched by `#matchpatterns`, which means that the enclosing match-pattern consumes it instead, and thinks that it's the beginning of a new top-level match. This throws everything off since the "new" pattern is in a nonsense state.

before:
<img width="183" alt="screen shot 2017-10-10 at 1 35 31 pm" src="https://user-images.githubusercontent.com/3012/31409234-041d69a0-adc0-11e7-846a-fffd6ea7af68.png">

after:
<img width="205" alt="screen shot 2017-10-10 at 1 35 58 pm" src="https://user-images.githubusercontent.com/3012/31409237-061497ec-adc0-11e7-9410-5456471937fe.png">
