### PR TITLE
Add indent patterns

### DIFF
--- a/settings/language-ocaml.cson
+++ b/settings/language-ocaml.cson
@@ -2,6 +2,8 @@
   'editor':
     'commentStart': '(* '
     'commentEnd': ' *)'
+    'increaseIndentPattern': '^.*(\\([^)"\\n]*|begin)$|\\bobject\\s*$|\\blet [a-zA-Z0-9_-]+( [^ ]+)+ =\\s*$|method[ \\t]+.*=[ \\t]*$|->[ \\t]*$|\\b(for|while)[ \\t]+.*[ \\t]+do[ \\t]*$|(\\btry$|\\bif\\s+.*\\sthen$|\\belse|[:=]\\s*sig|=\\s*struct)\\s*$'
+    'decreaseIndentPattern': '^\\s*(end|done|with|in|else)\\b|^\\s*;;|^[^\\("]*\\)'
 
 '.source.ocamllex':
   'editor':


### PR DESCRIPTION
@zertosh sent me his sublime regexes, which looked [like this](https://gist.github.com/gabelevi/a26980f139dd03f30554e0d028e51d97). Copy pasted them into my `~/.atom/packages/language-ocaml/settings/language-ocaml.cson`, replaced `\` with `\\`, loaded a new window, and tried editing a .ocaml file. 

* Writing `sdflksdjfsdklf` and hitting enter didn't cause an indent (same as before)
* Writing `begin` and hitting enter increased the indent (this is new)
* Writing `end` decreased the indent (this is new)